### PR TITLE
More logging cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +2960,50 @@ dependencies = [
  "quote",
  "syn 2.0.52",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rend"
@@ -4019,12 +4081,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio-serde = { version = "0.9", features = ["json", "cbor"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 tokio-util = { version = "0.7", features = ["full"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 x25519-dalek = { version = "2", features = ["serde"] }
 

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -169,15 +169,13 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                         keys::write_frost_keys(&keys_dir, key_package, public_key_package)
                             .context("Could not save frost keys")?;
                     info!("The new frost address is: {}", address);
+                    sender.broadcast(KeygenMessage::Done).await;
                 }
             }
             KeygenMessage::Done => {
                 done_set.insert(from);
                 if done_set.len() == peers_count {
-                    info!("All peers have generated their keys!");
-                    sender.broadcast(KeygenMessage::Done).await;
-                    info!("Shutting down in 10 seconds");
-                    sleep(Duration::from_secs(10)).await;
+                    info!("All peers have generated their keys! Shutting down.");
                     done_tx.send(()).await.unwrap();
                 }
             }

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -34,6 +34,7 @@ pub enum KeygenMessage {
 
 pub async fn run(config: &OracleConfig) -> Result<()> {
     let mut network = Network::new(config)?;
+    let peers_count = network.peers_count();
     let id = network.id.clone();
 
     let keys_dir = get_keys_directory()?;
@@ -57,7 +58,7 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
     // DKG has three rounds. We can perform round 1 on our own, it gets us information needed for round 2
     let (round1_secret_package, round1_package) = {
         let rng = thread_rng();
-        let max_signers = 1 + config.peers.len() as u16;
+        let max_signers = 1 + peers_count as u16;
         let min_signers = config
             .keygen
             .min_signers
@@ -123,7 +124,7 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                 }
 
                 round1_packages.insert(from_id, *package);
-                if round1_packages.len() == config.peers.len() {
+                if round1_packages.len() == peers_count {
                     info!("Round 1 complete! Beginning round 2");
                     // We have packages from every peer, and now we can start (or re-start) round 2
                     let (secret_package, outgoing_packages) =
@@ -139,7 +140,7 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                 }
 
                 round2_packages.insert(from_id, *package);
-                if round2_packages.len() == config.peers.len() {
+                if round2_packages.len() == peers_count {
                     // We have everything we need to compute our frost keys
                     let round2_secret_package = round2_secret_package.as_ref().unwrap();
                     let (key_package, public_key_package) =

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -179,7 +179,9 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                     info!("All peers have generated their keys! Press enter to shut down.");
                     spawn_blocking(|| {
                         std::io::stdin().read_line(&mut String::new()).unwrap();
-                    }).await.unwrap();
+                    })
+                    .await
+                    .unwrap();
                 }
             }
         }

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -175,12 +175,12 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
             KeygenMessage::Done => {
                 done_set.insert(from);
                 if done_set.len() == peers_count {
-                    done_tx.send(()).await.unwrap();
                     info!("All peers have generated their keys!");
                     sleep(Duration::from_secs(3)).await;
                     info!("Press enter to shut down.");
                     part1_broadcast_handle.abort();
                     part2_broadcast_handle.abort();
+                    done_tx.send(()).await.unwrap();
                     spawn_blocking(|| {
                         std::io::stdin().read_line(&mut String::new()).unwrap();
                     })

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -176,7 +176,9 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                 done_set.insert(from);
                 if done_set.len() == peers_count {
                     done_tx.send(()).await.unwrap();
-                    info!("All peers have generated their keys! Press enter to shut down.");
+                    info!("All peers have generated their keys!");
+                    sleep(Duration::from_secs(3)).await;
+                    info!("Press enter to shut down.");
                     part1_broadcast_handle.abort();
                     part2_broadcast_handle.abort();
                     spawn_blocking(|| {

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -176,7 +176,8 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                 if done_set.len() == peers_count {
                     info!("All peers have generated their keys!");
                     sender.broadcast(KeygenMessage::Done).await;
-                    info!("Shutting down");
+                    info!("Shutting down in 10 seconds");
+                    sleep(Duration::from_secs(10)).await;
                     done_tx.send(()).await.unwrap();
                 }
             }

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -170,8 +170,6 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                             .context("Could not save frost keys")?;
                     info!("The new frost address is: {}", address);
                     sender.broadcast(KeygenMessage::Done).await;
-                    part1_broadcast_handle.abort();
-                    part2_broadcast_handle.abort();
                 }
             }
             KeygenMessage::Done => {
@@ -179,6 +177,8 @@ pub async fn run(config: &OracleConfig) -> Result<()> {
                 if done_set.len() == peers_count {
                     done_tx.send(()).await.unwrap();
                     info!("All peers have generated their keys! Press enter to shut down.");
+                    part1_broadcast_handle.abort();
+                    part2_broadcast_handle.abort();
                     spawn_blocking(|| {
                         std::io::stdin().read_line(&mut String::new()).unwrap();
                     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,6 @@ struct Node {
 
 impl Node {
     pub fn new(config: Arc<OracleConfig>) -> Result<Self> {
-        // quorum is set to a majority of expected nodes (which includes ourself!)
-        let quorum = ((config.peers.len() + 1) / 2) + 1;
         let heartbeat = config.heartbeat();
         let timeout = config.timeout();
 
@@ -51,6 +49,9 @@ impl Node {
 
         // Construct a peer-to-peer network that can connect to peers, and dispatch messages to the correct state machine
         let mut network = Network::new(&config)?;
+
+        // quorum is set to a majority of expected nodes (which includes ourself!)
+        let quorum = ((network.peers_count() + 1) / 2) + 1;
 
         let (pa_tx, pa_rx) = watch::channel(vec![]);
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -58,6 +58,10 @@ impl Network {
         })
     }
 
+    pub fn peers_count(&self) -> usize {
+        self.core.peers_count()
+    }
+
     pub fn keygen_channel(&mut self) -> NetworkChannel<KeygenMessage> {
         create_channel(&mut self.keygen)
     }

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -145,7 +145,7 @@ impl Core {
 
         let peers = {
             let peers: Result<Vec<Peer>> = config.peers.iter().map(parse_peer).collect();
-            Arc::new(peers?)
+            Arc::new(peers?.into_iter().filter(|p| p.id != id).collect())
         };
         Ok(Self {
             id,
@@ -155,6 +155,10 @@ impl Core {
             outgoing_rx: Arc::new(Mutex::new(outgoing_rx)),
             incoming_tx: Arc::new(incoming_tx),
         })
+    }
+
+    pub fn peers_count(&self) -> usize {
+        self.peers.len()
     }
 
     pub async fn handle_network(self) -> Result<()> {

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -336,10 +336,10 @@ impl Core {
             .await
         {
             Ok(_) => {
-                trace!("Outgoing Hello sent");
+                trace!(them, "Outgoing Hello sent");
             }
             Err(e) => {
-                warn!("Failed to send hello: {:?}", e);
+                warn!(them, "Failed to send hello: {:?}", e);
             }
         }
     }

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -19,7 +19,7 @@ use tokio::{
         TcpListener, TcpStream,
     },
     select,
-    sync::{mpsc, Mutex},
+    sync::{mpsc, oneshot, Mutex},
     task::JoinSet,
     time::sleep,
 };
@@ -100,6 +100,7 @@ enum Message {
     OpenConnection(Box<OpenConnectionMessage>), // boxed because it's big
     ConfirmConnection(ConfirmConnectionMessage),
     Application(ApplicationMessage),
+    Disconnect(String),
 }
 
 #[derive(Clone)]
@@ -270,6 +271,13 @@ impl Core {
 
         let message = match stream.next().await {
             Some(Ok(Message::OpenConnection(message))) => message,
+            Some(Ok(Message::Disconnect(reason))) => {
+                warn!(
+                    "Other party disconnected immediately on connection: {}",
+                    reason
+                );
+                return;
+            }
             Some(Ok(other)) => {
                 warn!("Expected Hello, got {:?}", other);
                 return;
@@ -299,6 +307,12 @@ impl Core {
         let peer_id = compute_node_id(&id_public_key);
         let Some(peer) = self.peers.iter().find(|p| p.id == peer_id) else {
             warn!("Unrecognized peer {}", peer_id);
+            let _ = sink
+                .send(Message::Disconnect(format!(
+                    "Unrecognized peer {}",
+                    peer_id
+                )))
+                .await;
             return;
         };
         let them = peer.label.clone();
@@ -307,6 +321,12 @@ impl Core {
         let signature = message.signature;
         if let Err(e) = id_public_key.verify(ecdh_public_key.as_bytes(), &signature) {
             warn!(them, "Signature does not match public key: {}", e);
+            let _ = sink
+                .send(Message::Disconnect(format!(
+                    "Signature does not match public key: {}",
+                    e
+                )))
+                .await;
             return;
         }
 
@@ -314,6 +334,9 @@ impl Core {
         // (We look up the "incoming connection" sender, so if we don't recognize them we fail here)
         let Some(connection_tx) = txs.get(&peer_id) else {
             warn!(them, "Other node not recognized");
+            let _ = sink
+                .send(Message::Disconnect("Other node not recognized".into()))
+                .await;
             return;
         };
         if let Err(e) = connection_tx
@@ -395,7 +418,8 @@ impl Core {
     }
 
     async fn connect_to_peer(&self, peer: &Peer) -> Result<OutgoingConnection> {
-        trace!("Attempting to connect to {} ({})", peer.id, peer.label);
+        let them = &peer.id;
+        trace!("Attempting to connect to {} ({})", them, peer.label);
         let stream = TcpStream::connect(&peer.address)
             .await
             .context("error opening connection")?;
@@ -429,11 +453,14 @@ impl Core {
         sink.send(Message::OpenConnection(Box::new(message)))
             .await
             .context("error sending open message")?;
-        trace!("Outgoing Open request sent");
+        trace!(%them, "Outgoing Open request sent");
 
         // Wait for the other side to respond
         let message = match stream.next().await {
             Some(Ok(Message::ConfirmConnection(message))) => message,
+            Some(Ok(Message::Disconnect(reason))) => {
+                return Err(anyhow!("other side disconnected: {}", reason))
+            }
             Some(Ok(other)) => {
                 return Err(anyhow!("expected ConfirmConnection, got {:?}", other));
             }
@@ -447,9 +474,18 @@ impl Core {
 
         // They've signed our nonce, let's confirm they did it right
         let signature = message.signature;
-        peer.public_key
+        let verification_result = peer
+            .public_key
             .verify(ecdh_public_key.as_bytes(), &signature)
-            .context("signature does not match public key")?;
+            .context("signature does not match public key");
+        if verification_result.is_err() {
+            sink.send(Message::Disconnect(
+                "signature does not match public key".into(),
+            ))
+            .await
+            .context("error sending disconnect message")?;
+            verification_result?;
+        }
 
         // and we're all set!
         Ok(OutgoingConnection { ecdh_secret, sink })
@@ -477,6 +513,7 @@ impl Core {
         let mut sink = outgoing_connection.sink;
         let send_chacha = chacha.clone();
         let them = peer.id.clone();
+        let (last_message_tx, last_message_rx) = oneshot::channel();
         let send_task = async move {
             while let Some(message) = outgoing_message_rx.recv().await {
                 let message = ApplicationMessage::encrypt(message, &send_chacha);
@@ -484,6 +521,9 @@ impl Core {
                     warn!(them = %them, "Failed to send message: {:?}", e);
                     break;
                 }
+            }
+            if let Ok(dc_reason) = last_message_rx.await {
+                let _ = sink.send(Message::Disconnect(dc_reason)).await;
             }
         };
 
@@ -497,34 +537,33 @@ impl Core {
                         let message = match message.decrypt(&chacha) {
                             Ok(message) => message,
                             Err(e) => {
-                                warn!(them, "Failed to decrypt incoming message: {:#}", e);
-                                break;
+                                return format!("Failed to decrypt incoming message: {:#}", e);
                             }
                         };
                         if let Err(e) = incoming_message_tx.send((peer.id.clone(), message)).await {
-                            warn!(them, "Failed to send message: {:?}", e);
-                            break;
+                            return format!("Failed to send message: {:?}", e);
                         }
                     }
                     // If someone tries to Hello us again, break it off
                     Ok(other) => {
-                        warn!(them, "Unexpected message: {:?}", other);
-                        break;
+                        return format!("Unexpected message: {:?}", other);
                     }
                     // Someone is sending us messages that we can't parse
                     Err(e) => {
-                        warn!(them, "Failed to parse message: {:?}", e);
-                        break;
+                        return format!("Failed to parse message: {:?}", e);
                     }
                 }
             }
-            warn!(them, "Incoming connection Disconnected");
+            "Other side disconnected".into()
         };
 
         // Run until either the sender or receiver task stops running, then return so we can reconnect
         select! {
             _ = send_task => {},
-            _ = recv_task => {},
+            dc_reason = recv_task => {
+                warn!(them, "we disconnected: {}", dc_reason);
+                let _ = last_message_tx.send(dc_reason);
+            },
         };
 
         // try to warn raft that we aren't connected anymore


### PR DESCRIPTION
- Tweaks the TRACE level logs so that tokio_util doesn't spam as much
- Add `them` to some log statements missing it
- Always transmit disconnect reason to other party
- Ignore our own self in the `peers` list (to make it easier to use the same peer list in every node)
- Remove noisy logs when nodes disconnect after DKG runs