### PR TITLE
Set TCP_NODELAY

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -435,6 +435,10 @@ impl Core {
             "Outgoing connection to: {}",
             stream.peer_addr().unwrap()
         );
+        stream
+            .set_nodelay(true)
+            .context("error setting TCP_NODELAY")?;
+        trace!(them, "Set TCP_NODELAY");
 
         let (read, write) = stream.into_split();
 

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -515,7 +515,7 @@ impl Core {
         outgoing_message_rx: &mut mpsc::Receiver<AppMessage>,
     ) {
         let them = peer.label.clone();
-        info!("Connected to {} ({})", them, peer.id);
+        info!(them, "Connected to {}", peer.id);
         // try to tell Raft that we are definitely connected
         let _ = self
             .incoming_tx


### PR DESCRIPTION
One node in our test set has connections which hang when reaching out to other nodes. I've read that this perfidious behavior can be caused by Nagle's algorithm, which buffers TCP packets until the most recent packet has been acknowledged.

Setting `TCP_NODELAY` won't fix whatever issue is making the connection hang, but I think it might make the application fail later with a disconnect error _instead of_ hanging. That's an improvement because the node can try recovering from that by reconnecting, and because we might get error messages that help us debug.

Also, go add more trace logs and fix the context in existing trace logs again