### PR TITLE
Continue hardening networking and DKG

### DIFF
--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -1,4 +1,6 @@
 mod logic;
+#[cfg(test)]
+mod tests;
 
 use logic::GeneratedKeys;
 pub use logic::KeygenMessage;

--- a/src/dkg/logic.rs
+++ b/src/dkg/logic.rs
@@ -219,7 +219,7 @@ pub async fn run(
                     if round1_packages.len() == peers_count {
                         // We have packages from every peer, and now we can start (or re-start) round 2
                         session_id = compute_session_id(&round1_hashes);
-                        info!(session_id, "Round 1 complete! Beginning round 2");
+                        info!(session_id, "Round 1 complete! Beginning round 2, waiting for all peers to send round 2 packages");
 
                         round2_packages.clear();
 
@@ -267,7 +267,7 @@ pub async fn run(
                         let round2_secret_package = round2_secret_package.as_ref().unwrap();
                         let (key_package, public_key_package) =
                             part3(round2_secret_package, &round1_packages, &round2_packages)?;
-                        info!(session_id, "Key generation complete!");
+                        info!(session_id, "Key generation complete! Waiting for all peers to confirm they have generated keys as well");
 
                         generated_keys.replace(GeneratedKeys(key_package, public_key_package));
                         done_sets

--- a/src/dkg/logic.rs
+++ b/src/dkg/logic.rs
@@ -6,10 +6,9 @@ use std::{
 
 use crate::{
     cbor::{CborDkgRound1Package, CborDkgRound2Package},
-    network::{NetworkChannel, NodeId},
+    network::{NetworkChannel, NetworkSender, NodeId},
 };
 use anyhow::{anyhow, Result};
-use dashmap::DashMap;
 use frost_ed25519::{
     keys::{
         dkg::{part1, part2, part3, round1, round2},
@@ -21,11 +20,8 @@ use futures::future::join_all;
 use minicbor::{Decode, Encode};
 use pallas_crypto::hash::Hasher;
 use rand::thread_rng;
-use tokio::{
-    sync::{watch, RwLock},
-    time::sleep,
-};
-use tracing::{debug, info, trace, Instrument};
+use tokio::{join, select, sync::RwLock, time::sleep};
+use tracing::{debug, info, trace};
 
 #[derive(Decode, Encode, Clone, Debug)]
 pub struct Part1Message {
@@ -60,6 +56,85 @@ pub enum KeygenMessage {
 #[derive(Clone, Debug)]
 pub struct GeneratedKeys(pub KeyPackage, pub PublicKeyPackage);
 
+struct BroadcastState {
+    sender: NetworkSender<KeygenMessage>,
+    session_id: String,
+    round1_package: round1::Package,
+    round2_packages: BTreeMap<NodeId, round2::Package>,
+    done: bool,
+}
+
+impl BroadcastState {
+    fn new(sender: NetworkSender<KeygenMessage>, round1_package: round1::Package) -> Self {
+        Self {
+            sender,
+            session_id: "".into(),
+            round1_package,
+            round2_packages: BTreeMap::new(),
+            done: false,
+        }
+    }
+
+    fn broadcast_round_2(
+        &mut self,
+        session_id: &str,
+        round2_packages: BTreeMap<NodeId, round2::Package>,
+    ) {
+        self.session_id = session_id.to_string();
+        self.round2_packages = round2_packages;
+        self.done = false;
+    }
+
+    fn broadcast_done(&mut self, session_id: &str) {
+        assert!(self.session_id == session_id);
+        self.done = true;
+    }
+
+    async fn send(&self) {
+        let sender = self.sender.clone();
+        let round1_package = self.round1_package.clone();
+        let broadcast_round1 = async move {
+            // We should always be broadcasting the package from round 1,
+            // in case a node disconnected and reconnected
+            sender
+                .broadcast(KeygenMessage::Part1(Part1Message {
+                    package: Box::new(round1_package.into()),
+                }))
+                .await;
+        };
+
+        let sender = self.sender.clone();
+        let session_id = self.session_id.clone();
+        let round2_packages = self.round2_packages.clone();
+        let broadcast_round2 = async move {
+            // We should sending out the pacakges from round 2 once we have them
+            let tasks = round2_packages.into_iter().map(|(node_id, package)| {
+                sender.send(
+                    node_id,
+                    KeygenMessage::Part2(Part2Message {
+                        session_id: session_id.clone(),
+                        package: Box::new(package.into()),
+                    }),
+                )
+            });
+            join_all(tasks).await;
+        };
+
+        let sender = self.sender.clone();
+        let session_id = self.session_id.clone();
+        let broadcast_done = async move {
+            // If we have finished the DKG process, let the world know
+            if self.done {
+                sender
+                    .broadcast(KeygenMessage::Done(DoneMessage { session_id }))
+                    .await
+            }
+        };
+
+        join!(broadcast_round1, broadcast_round2, broadcast_done);
+    }
+}
+
 pub async fn run(
     id: NodeId,
     channel: NetworkChannel<KeygenMessage>,
@@ -67,7 +142,6 @@ pub async fn run(
     min_signers: u16,
 ) -> Result<GeneratedKeys> {
     let peers_count = max_signers as usize - 1;
-    let identifier_lookup: Arc<DashMap<Identifier, NodeId>> = Arc::new(DashMap::new());
 
     let (sender, mut receiver) = channel.split();
 
@@ -80,171 +154,155 @@ pub async fn run(
         part1(identifier, max_signers, min_signers, rng)?
     };
 
-    // A "session id" is a hash of all the packages generated during round 1 of the DKG process.
-    // Every node needs to agree on the "session id" during round 2 and beyond, so that state from
-    // any older DKG session doesn't bleed over.
-    // If a node quits and rejoins during DKG generation, it'll send a new round 1 package to every participant,
-    // so they'll all generate a new "session id".
-    let current_session_id = Arc::new(RwLock::new(String::new()));
-    let mut round1_hashes = BTreeMap::new();
-    round1_hashes.insert(
-        identifier,
-        round1_package
-            .serialize()
-            .expect("error serializing package"),
-    );
+    let broadcast_state = Arc::new(RwLock::new(BroadcastState::new(
+        sender.clone(),
+        round1_package.clone(),
+    )));
 
-    // Keep broadcasting our round 1 payload until everyone has finished (in case someone disconnects or joins late)
-    let part1_sender = sender.clone();
-    let part1_broadcast_handle = tokio::spawn(
-        async move {
-            loop {
-                let message = Part1Message {
-                    package: Box::new(round1_package.clone().into()),
-                };
-                part1_sender.broadcast(KeygenMessage::Part1(message)).await;
-                sleep(Duration::from_secs(1)).await;
-            }
+    let bc_state = broadcast_state.clone();
+    let broadcast_handle = async move {
+        loop {
+            let state = bc_state.read().await;
+            state.send().await;
+            drop(state);
+            sleep(Duration::from_secs(1)).await
         }
-        .in_current_span(),
-    );
+    };
 
-    // Send our round 2 payloads (once we have them)
-    let (outgoing_round2_packages_tx, outgoing_round2_packages_rx) =
-        watch::channel(BTreeMap::<Identifier, round2::Package>::new());
-    let identifiers = identifier_lookup.clone();
-    let part2_session_id = current_session_id.clone();
-    let part2_sender = sender.clone();
-    let part2_broadcast_handle = tokio::spawn(
-        async move {
-            loop {
-                // clone this so we aren't holding a lock for too long
-                let round2_packages = outgoing_round2_packages_rx.borrow().clone();
-                let session_id = part2_session_id.read().await.clone();
-                let tasks = round2_packages.into_iter().map(|(identifier, package)| {
-                    let to: NodeId = identifiers.get(&identifier).unwrap().clone();
-                    let message = Part2Message {
-                        session_id: session_id.clone(),
-                        package: Box::new(package.into()),
-                    };
-                    part2_sender.send(to, KeygenMessage::Part2(message))
-                });
-                join_all(tasks).await;
-                sleep(Duration::from_secs(1)).await;
-            }
-        }
-        .in_current_span(),
-    );
+    let receive_task = async move {
+        // A "session id" is a hash of all the packages generated during round 1 of the DKG process.
+        // Every node needs to agree on the "session id" during round 2 and beyond, so that state from
+        // any older DKG session doesn't bleed over.
+        // If a node quits and rejoins during DKG generation, it'll send a new round 1 package to every participant,
+        // so they'll all generate a new "session id".
+        let mut session_id = String::new();
+        let mut round1_hashes = BTreeMap::new();
+        round1_hashes.insert(
+            identifier,
+            round1_package
+                .serialize()
+                .expect("error serializing package"),
+        );
 
-    let mut round1_packages = BTreeMap::new();
-    let mut round2_secret_package: Option<round2::SecretPackage> = None;
-    let mut round2_packages = BTreeMap::new();
+        let mut round1_packages = BTreeMap::new();
+        let mut round2_secret_package: Option<round2::SecretPackage> = None;
+        let mut round2_packages = BTreeMap::new();
 
-    // Track which nodes have said they've finished in each session, so that we know when to disconnect the network.
-    let mut done_sets = HashMap::<String, HashSet<NodeId>>::new();
-    let mut generated_keys = None;
+        // Track which nodes have said they've finished in each session, so that we know when to disconnect the network.
+        let mut done_sets = HashMap::<String, HashSet<NodeId>>::new();
+        let mut generated_keys = None;
 
-    // And now that we've got our senders all set up, we're ready to run our receiver logic
-    while let Some(message) = receiver.recv().await {
-        let from = message.from;
+        let mut identifier_lookup: BTreeMap<Identifier, NodeId> = BTreeMap::new();
 
-        // The DKG algorithm uses Identifier to identify a node, but our network uses NodeId
-        // Maintain a lookup for later.
-        let from_id = Identifier::derive(from.as_bytes())?;
-        identifier_lookup.insert(from_id, from.clone());
+        while let Some(message) = receiver.recv().await {
+            let from = message.from;
 
-        match message.data {
-            KeygenMessage::Part1(Part1Message { package }) => {
-                let package: round1::Package = (*package).into();
-                if round1_packages.get(&from_id) == Some(&package) {
-                    // We've seen this one
-                    continue;
-                }
-                debug!(%from, "Received new round 1 package");
+            // The DKG algorithm uses Identifier to identify a node, but our network uses NodeId
+            // Maintain a lookup for later.
+            let from_id = Identifier::derive(from.as_bytes())?;
+            identifier_lookup.insert(from_id, from.clone());
 
-                round1_hashes.insert(
-                    from_id,
-                    package.serialize().expect("error serializing package"),
-                );
-                round1_packages.insert(from_id, package);
-                if round1_packages.len() == peers_count {
-                    // We have packages from every peer, and now we can start (or re-start) round 2
-                    let session_id = compute_session_id(&round1_hashes);
+            match message.data {
+                KeygenMessage::Part1(Part1Message { package }) => {
+                    let package: round1::Package = (*package).into();
+                    if round1_packages.get(&from_id) == Some(&package) {
+                        // We've seen this one
+                        continue;
+                    }
+                    debug!(%from, "Received new round 1 package");
 
-                    // hold onto this mutex until we've finished setting up the state for round
-                    let mut curr = current_session_id.write().await;
-                    curr.clone_from(&session_id);
-                    info!(session_id, "Round 1 complete! Beginning round 2");
-
-                    round2_packages.clear();
-
-                    let (secret_package, outgoing_packages) =
-                        part2(round1_secret_package.clone(), &round1_packages)?;
-                    round2_secret_package.replace(secret_package);
-                    outgoing_round2_packages_tx.send_replace(outgoing_packages);
-                }
-            }
-            KeygenMessage::Part2(Part2Message {
-                session_id: other_session_id,
-                package,
-            }) => {
-                let session_id = current_session_id.read().await.clone();
-                if session_id != other_session_id {
-                    trace!(
-                        session_id,
-                        other_session_id,
-                        "Round 2 message received from another session"
+                    round1_hashes.insert(
+                        from_id,
+                        package.serialize().expect("error serializing package"),
                     );
-                    continue;
-                }
+                    round1_packages.insert(from_id, package);
+                    if round1_packages.len() == peers_count {
+                        // We have packages from every peer, and now we can start (or re-start) round 2
+                        session_id = compute_session_id(&round1_hashes);
+                        info!(session_id, "Round 1 complete! Beginning round 2");
 
-                let package: round2::Package = (*package).into();
-                if round2_packages.get(&from_id) == Some(&package) {
-                    // We've seen this one
-                    continue;
-                }
-                debug!(%from, session_id, "Received new round 2 package");
+                        round2_packages.clear();
 
-                round2_packages.insert(from_id, package);
-                if round2_packages.len() == peers_count {
-                    // We have everything we need to compute our frost keys
-                    let round2_secret_package = round2_secret_package.as_ref().unwrap();
-                    let (key_package, public_key_package) =
-                        part3(round2_secret_package, &round1_packages, &round2_packages)?;
-                    info!(session_id, "Key generation complete!");
-                    generated_keys.replace(GeneratedKeys(key_package, public_key_package));
-                    done_sets
-                        .entry(session_id.clone())
-                        .or_default()
-                        .insert(id.clone());
-                    sender
-                        .broadcast(KeygenMessage::Done(DoneMessage { session_id }))
-                        .await;
+                        let (secret_package, outgoing_packages) =
+                            part2(round1_secret_package.clone(), &round1_packages)?;
+                        round2_secret_package.replace(secret_package);
+
+                        let round2_packages = outgoing_packages
+                            .into_iter()
+                            .map(|(identifier, package)| {
+                                let id = identifier_lookup.get(&identifier).unwrap().clone();
+                                (id, package)
+                            })
+                            .collect();
+
+                        broadcast_state
+                            .write()
+                            .await
+                            .broadcast_round_2(&session_id, round2_packages)
+                    }
+                }
+                KeygenMessage::Part2(Part2Message {
+                    session_id: other_session_id,
+                    package,
+                }) => {
+                    if session_id != other_session_id {
+                        trace!(
+                            session_id,
+                            other_session_id,
+                            "Round 2 message received from another session"
+                        );
+                        continue;
+                    }
+
+                    let package: round2::Package = (*package).into();
+                    if round2_packages.get(&from_id) == Some(&package) {
+                        // We've seen this one
+                        continue;
+                    }
+                    debug!(%from, session_id, "Received new round 2 package");
+
+                    round2_packages.insert(from_id, package);
+                    if round2_packages.len() == peers_count {
+                        // We have everything we need to compute our frost keys
+                        let round2_secret_package = round2_secret_package.as_ref().unwrap();
+                        let (key_package, public_key_package) =
+                            part3(round2_secret_package, &round1_packages, &round2_packages)?;
+                        info!(session_id, "Key generation complete!");
+
+                        generated_keys.replace(GeneratedKeys(key_package, public_key_package));
+                        done_sets
+                            .entry(session_id.clone())
+                            .or_default()
+                            .insert(id.clone());
+                        broadcast_state.write().await.broadcast_done(&session_id);
+                    }
+                }
+                KeygenMessage::Done(DoneMessage { session_id }) => {
+                    debug!(%from, session_id, "Received new done message");
+                    done_sets.entry(session_id).or_default().insert(from);
                 }
             }
-            KeygenMessage::Done(DoneMessage { session_id }) => {
-                debug!(%from, session_id, "Received new done message");
-                done_sets.entry(session_id).or_default().insert(from);
+
+            // If every node has finished generating keys, shut this down.
+            if done_sets
+                .get(&session_id)
+                .is_some_and(|set| set.len() == max_signers as usize)
+            {
+                // We're done!
+                info!("All peers have generated keys!");
+                sleep(Duration::from_secs(1)).await;
+
+                return generated_keys.ok_or(anyhow!("Generated keys missing"));
             }
         }
 
-        // If every node has finished generating keys, shut this down.
-        let session_id = current_session_id.read().await;
-        if done_sets
-            .get(&*session_id)
-            .is_some_and(|set| set.len() == max_signers as usize)
-        {
-            // We're done!
-            info!("All peers have generated keys!");
-            sleep(Duration::from_secs(1)).await;
+        Err(anyhow!("Network closed before we could generate keys"))
+    };
 
-            part1_broadcast_handle.abort();
-            part2_broadcast_handle.abort();
-            return generated_keys.ok_or(anyhow!("Generated keys missing"));
-        }
+    select! {
+        _ = broadcast_handle => { Err(anyhow!("Broadcasting task ended early")) }
+        result = receive_task => { result }
     }
-
-    Err(anyhow!("Network closed before we could generate keys"))
 }
 
 fn compute_session_id(round1_hashes: &BTreeMap<Identifier, Vec<u8>>) -> String {

--- a/src/dkg/tests.rs
+++ b/src/dkg/tests.rs
@@ -1,0 +1,204 @@
+use std::{collections::HashSet, pin::Pin};
+
+use anyhow::Result;
+use futures::{Future, FutureExt};
+use tokio::select;
+
+use crate::network::{NodeId, OutgoingMessage};
+
+use super::{
+    logic::{self, GeneratedKeys},
+    KeygenMessage,
+};
+
+type TestNetwork = crate::network::TestNetwork<KeygenMessage>;
+
+struct Participant {
+    id: NodeId,
+    max_signers: u16,
+    min_signers: u16,
+    prior_session_id: Option<String>,
+    task: Pin<Box<dyn Future<Output = Result<GeneratedKeys>>>>,
+}
+
+impl Participant {
+    pub fn new(network: &mut TestNetwork, max_signers: u16, min_signers: u16) -> Self {
+        let (id, channel) = network.connect();
+        let task = logic::run(id.clone(), channel, max_signers, min_signers).boxed();
+        Self {
+            id,
+            max_signers,
+            min_signers,
+            prior_session_id: None,
+            task,
+        }
+    }
+
+    pub async fn run_until_round_1_sent(&mut self, network: &mut TestNetwork) {
+        let sent_to = self
+            .run_until_message_sent(network, |message| {
+                if let KeygenMessage::Part1(_) = message.data {
+                    Some(message.to)
+                } else {
+                    None
+                }
+            })
+            .await;
+        assert_eq!(sent_to, None);
+    }
+
+    pub async fn run_until_round_2_sent(
+        &mut self,
+        network: &mut TestNetwork,
+        targets: Vec<&NodeId>,
+    ) {
+        let mut waiting_for: HashSet<NodeId> = targets.into_iter().cloned().collect();
+        let mut new_session_id = None;
+        while !waiting_for.is_empty() {
+            let (to, session_id) = self
+                .run_until_message_sent(network, |message| {
+                    if let KeygenMessage::Part2(p2message) = message.data {
+                        Some((message.to, p2message.session_id))
+                    } else {
+                        None
+                    }
+                })
+                .await;
+            if self.prior_session_id.as_ref() == Some(&session_id) {
+                continue;
+            }
+            new_session_id = Some(session_id);
+            waiting_for.remove(&to.unwrap());
+        }
+        self.prior_session_id = new_session_id;
+    }
+
+    pub async fn run_until_done_sent(&mut self, network: &mut TestNetwork) {
+        self.run_until_message_sent(network, |message| {
+            if let KeygenMessage::Done(_) = message.data {
+                Some(())
+            } else {
+                None
+            }
+        })
+        .await;
+    }
+
+    pub async fn run_until_shutdown(self) -> GeneratedKeys {
+        self.task.await.unwrap()
+    }
+
+    pub async fn reconnect(&mut self, network: &mut TestNetwork) {
+        let channel = network.reconnect(&self.id);
+        let task = logic::run(self.id.clone(), channel, self.max_signers, self.min_signers).boxed();
+        self.task = task;
+    }
+
+    async fn run_until_message_sent<T, F: Fn(OutgoingMessage<KeygenMessage>) -> Option<T>>(
+        &mut self,
+        network: &mut TestNetwork,
+        cond: F,
+    ) -> T {
+        let id = self.id.clone();
+        let get_message_task = async move {
+            while let Some(message) = network.next_message_from(&id).await {
+                if let Some(value) = cond(message) {
+                    return value;
+                }
+            }
+            panic!("Network has shut down!");
+        };
+        select! {
+            value = get_message_task => value,
+            result = &mut self.task => {
+                match result {
+                    Ok(_) => panic!("Generated keys too early"),
+                    Err(err) => panic!("Error while generating keys: {:#}", err)
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn should_generate_keys() {
+    let mut network = TestNetwork::new();
+    let max_signers = 2;
+    let min_signers = 2;
+    let mut p1 = Participant::new(&mut network, max_signers, min_signers);
+    let mut p2 = Participant::new(&mut network, max_signers, min_signers);
+
+    p1.run_until_round_1_sent(&mut network).await;
+    p2.run_until_round_1_sent(&mut network).await;
+
+    p1.run_until_round_2_sent(&mut network, vec![&p2.id]).await;
+    p2.run_until_round_2_sent(&mut network, vec![&p1.id]).await;
+
+    p1.run_until_done_sent(&mut network).await;
+    p2.run_until_done_sent(&mut network).await;
+
+    let p1_keys = p1.run_until_shutdown().await;
+    let p2_keys = p2.run_until_shutdown().await;
+    assert_eq!(p1_keys.1, p2_keys.1);
+}
+
+#[tokio::test]
+async fn should_generate_keys_after_disconnect() {
+    let mut network = TestNetwork::new();
+    let max_signers = 2;
+    let min_signers = 2;
+    let mut p1 = Participant::new(&mut network, max_signers, min_signers);
+    let mut p2 = Participant::new(&mut network, max_signers, min_signers);
+
+    p1.run_until_round_1_sent(&mut network).await;
+    p2.run_until_round_1_sent(&mut network).await;
+
+    p1.run_until_round_2_sent(&mut network, vec![&p2.id]).await;
+    p2.run_until_round_2_sent(&mut network, vec![&p1.id]).await;
+
+    p1.reconnect(&mut network).await;
+
+    p1.run_until_round_1_sent(&mut network).await;
+    p2.run_until_round_1_sent(&mut network).await;
+
+    p1.run_until_round_2_sent(&mut network, vec![&p2.id]).await;
+    p2.run_until_round_2_sent(&mut network, vec![&p1.id]).await;
+
+    p1.run_until_done_sent(&mut network).await;
+    p2.run_until_done_sent(&mut network).await;
+
+    let p1_keys = p1.run_until_shutdown().await;
+    let p2_keys = p2.run_until_shutdown().await;
+    assert_eq!(p1_keys.1, p2_keys.1);
+}
+
+#[tokio::test]
+async fn should_generate_keys_if_other_disconnects_after_we_finish() {
+    let mut network = TestNetwork::new();
+    let max_signers = 2;
+    let min_signers = 2;
+    let mut p1 = Participant::new(&mut network, max_signers, min_signers);
+    let mut p2 = Participant::new(&mut network, max_signers, min_signers);
+
+    p1.run_until_round_1_sent(&mut network).await;
+    p2.run_until_round_1_sent(&mut network).await;
+
+    p1.run_until_round_2_sent(&mut network, vec![&p2.id]).await;
+    p2.run_until_round_2_sent(&mut network, vec![&p1.id]).await;
+
+    p1.run_until_done_sent(&mut network).await;
+    p2.reconnect(&mut network).await;
+
+    p1.run_until_round_1_sent(&mut network).await;
+    p2.run_until_round_1_sent(&mut network).await;
+
+    p1.run_until_round_2_sent(&mut network, vec![&p2.id]).await;
+    p2.run_until_round_2_sent(&mut network, vec![&p1.id]).await;
+
+    p1.run_until_done_sent(&mut network).await;
+    p2.run_until_done_sent(&mut network).await;
+
+    let p1_keys = p1.run_until_shutdown().await;
+    let p2_keys = p2.run_until_shutdown().await;
+    assert_eq!(p1_keys.1, p2_keys.1);
+}

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -249,25 +249,27 @@ impl Core {
     async fn send_messages(self, outgoing_message_txs: HashMap<NodeId, mpsc::Sender<AppMessage>>) {
         let mut outgoing_rx = self.outgoing_rx.lock_owned().await;
         while let Some((to, message)) = outgoing_rx.recv().await {
-            match to {
+            let recipients = match &to {
                 Some(id) => {
                     // Sending to one node
-                    let Some(sender) = outgoing_message_txs.get(&id) else {
+                    let Some(sender) = outgoing_message_txs.get(id) else {
                         warn!("Tried sending message to unrecognized node {}", id);
                         continue;
                     };
-                    if let Err(e) = sender.send(message).await {
-                        warn!("Could not send message to node {}: {}", id, e);
-                    }
+                    vec![(id, sender)]
                 }
                 None => {
                     // Broadcasting to all nodes
-                    for (id, sender) in outgoing_message_txs.iter() {
-                        if let Err(e) = sender.send(message.clone()).await {
-                            warn!("Could not send message to node {}: {}", id, e);
-                        }
-                    }
+                    outgoing_message_txs.iter().collect()
                 }
+            };
+            for (id, sender) in recipients {
+                match sender.try_send(message.clone()) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        warn!("Could not send message to {}: {}", id, err)
+                    }
+                };
             }
         }
     }

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -300,7 +300,10 @@ impl Core {
         stream: TcpStream,
         rxs: Arc<DashMap<NodeId, Mutex<mpsc::Receiver<AppMessage>>>>,
     ) {
-        trace!("Incoming connection from: {}", stream.peer_addr().unwrap());
+        trace!(
+            "Incoming connection from {}, waiting for OpenConnection message",
+            stream.peer_addr().unwrap()
+        );
 
         let mut them = format!("<unknown> ({})", stream.peer_addr().unwrap());
 
@@ -519,7 +522,10 @@ impl Core {
         sink.write(Message::OpenConnection(Box::new(message)))
             .await
             .context("error sending open message")?;
-        trace!(them, "OpenConnection message sent");
+        trace!(
+            them,
+            "OpenConnection message sent, waiting for ConfirmConnection response"
+        );
 
         // Wait for the other side to respond
         let message = match stream


### PR DESCRIPTION
- Add tests for DKG. They didn't uncover any real bugs, but they help to confirm that as long as the network is healthy, the state machine isn't getting stuck.
- Update a few mpsc senders so that when the target channels are full, they drop their input (and log a warning) rather than waiting for the channels to empty. This may address some problems we saw during testing, where nodes would "hang" when communicating after being disconnected for a while.
- During DKG, make each node repeatedly broadcast that it has finished (once per second). This hasn't come up during real testing, but it will prevent us from hanging forever if the "done" message gets dropped due to a temporary network blip.

Some other changes which shouldn't affect network resiliency:
- Include DKG packages in network requests, instead of their bytes. Keeps serialization concerns out of application logic.
- Don't use tokio::spawn to create "broadcast" tasks inside of DKG, just start tasks and `select!` them at the end. The `tokio::spawn` tasks were living for longer than they should while running tests.