### PR TITLE
Less noisy logs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: sundaeswap/butane-oracle
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/src/dkg/logic.rs
+++ b/src/dkg/logic.rs
@@ -75,7 +75,7 @@ impl BroadcastState {
         }
     }
 
-    fn broadcast_round_2(
+    async fn broadcast_round_2(
         &mut self,
         session_id: &str,
         round2_packages: BTreeMap<NodeId, round2::Package>,
@@ -83,11 +83,13 @@ impl BroadcastState {
         self.session_id = session_id.to_string();
         self.round2_packages = round2_packages;
         self.done = false;
+        self.send().await;
     }
 
-    fn broadcast_done(&mut self, session_id: &str) {
+    async fn broadcast_done(&mut self, session_id: &str) {
         assert!(self.session_id == session_id);
         self.done = true;
+        self.send().await;
     }
 
     async fn send(&self) {
@@ -239,6 +241,7 @@ pub async fn run(
                             .write()
                             .await
                             .broadcast_round_2(&session_id, round2_packages)
+                            .await;
                     }
                 }
                 KeygenMessage::Part2(Part2Message {
@@ -274,7 +277,7 @@ pub async fn run(
                             .entry(session_id.clone())
                             .or_default()
                             .insert(id.clone());
-                        broadcast_state.write().await.broadcast_done(&session_id);
+                        broadcast_state.write().await.broadcast_done(&session_id).await;
                     }
                 }
                 KeygenMessage::Done(DoneMessage { session_id }) => {

--- a/src/dkg/logic.rs
+++ b/src/dkg/logic.rs
@@ -277,7 +277,11 @@ pub async fn run(
                             .entry(session_id.clone())
                             .or_default()
                             .insert(id.clone());
-                        broadcast_state.write().await.broadcast_done(&session_id).await;
+                        broadcast_state
+                            .write()
+                            .await
+                            .broadcast_done(&session_id)
+                            .await;
                     }
                 }
                 KeygenMessage::Done(DoneMessage { session_id }) => {


### PR DESCRIPTION
- Add docker image publishing (I would be shocked if this worked on the first try)
- Make error message when peers are not connected less noisy
- Speed up DKG tests by immediately publishing messages on state changes