### PR TITLE
Kupo hardening and health reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,11 +2037,13 @@ dependencies = [
 [[package]]
 name = "kupon"
 version = "0.1.0"
-source = "git+https://github.com/SundaeSwap-finance/kupon?rev=9d5eb1b#9d5eb1b8966609a77c0e93bc63a522cd17cd948e"
+source = "git+https://github.com/SundaeSwap-finance/kupon?rev=06dfda3#06dfda3c82f3dffa624214e15d84afff42c7027a"
 dependencies = [
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "thiserror",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,10 +903,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-crc32"
-version = "1.3.0"
+name = "const-crc32-nostd"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d13f542d70e5b339bf46f6f74704ac052cfd526c58cd87996bd1ef4615b9a0"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1068,16 +1068,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rand_core 0.6.4",
  "rustc_version 0.4.0",
  "subtle",
@@ -1212,13 +1211,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
+checksum = "0a6433aac097572ea8ccc60b3f2e756c661c9aeed9225cdd4d0cb119cb7ff6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1438,31 +1437,32 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d6280625f1603d160df24b23e4984a6a7286f41455ae606823d0104c32e834"
+checksum = "ed1383227a6606aacf5df9a17ff57824c6971a0ab225b69b911bec0ba7bbb869"
 dependencies = [
  "byteorder",
- "const-crc32",
+ "const-crc32-nostd",
  "debugless-unwrap",
  "derive-getters",
  "document-features",
  "hex",
- "itertools",
+ "itertools 0.13.0",
  "postcard",
  "rand_core 0.6.4",
  "serde",
  "serdect",
  "thiserror",
+ "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
 ]
 
 [[package]]
 name = "frost-ed25519"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b359e465bc1024663fd6cb68c3eda44d00c151246419857885f2bf267f1168ea"
+checksum = "bab23316e09987113dc8a2a8f0b656d7f1b24dc2afdc8c34df98276d1158c97d"
 dependencies = [
  "curve25519-dalek",
  "document-features",
@@ -1474,13 +1474,14 @@ dependencies = [
 
 [[package]]
 name = "frost-rerandomized"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c58f58ea009000db490efd9a3936d0035647a2b00c7ba8f3868c2ed0306b0b"
+checksum = "bdb14a6054f9ce5aa4912c60c11392d42c43acec8295ee1df1f67a9d0b7a73ee"
 dependencies = [
  "derive-getters",
  "document-features",
  "frost-core",
+ "hex",
  "rand_core 0.6.4",
 ]
 
@@ -2009,6 +2010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -2549,12 +2559,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polling"
@@ -3593,6 +3597,26 @@ name = "thiserror-impl"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,11 +1175,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
 dependencies = [
  "cfg-if 1.0.0",
+ "crossbeam-utils",
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
@@ -2036,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "kupon"
 version = "0.1.0"
-source = "git+https://github.com/SundaeSwap-finance/kupon?rev=890bed5#890bed54078f0638714ebe072588f57e319135c4"
+source = "git+https://github.com/SundaeSwap-finance/kupon?rev=9d5eb1b#9d5eb1b8966609a77c0e93bc63a522cd17cd948e"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ chacha20poly1305 = "0.10"
 cynic = "3.4"
 clap = { version = "4.5.1", features = ["derive"] }
 config = "0.14"
-dashmap = "5.5.3"
+dashmap = "6"
 ed25519 = { version = "2.2", features = ["pkcs8", "pem"] }
 ed25519-dalek = { version = "2.1" }
 frost-ed25519 = { version = "1.0.0", features = ["serialization"] }
 futures = "0.3"
 hex = "0.4.3"
-kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "890bed5" }
+kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "9d5eb1b" }
 minicbor = { version = "0.20", features = ["derive", "std"] }
 minicbor-io = { version = "0.15", features = ["async-io"] }
 num-bigint = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ config = "0.14"
 dashmap = "6"
 ed25519 = { version = "2.2", features = ["pkcs8", "pem"] }
 ed25519-dalek = { version = "2.1" }
-frost-ed25519 = { version = "1.0.0", features = ["serialization"] }
+frost-ed25519 = { version = "2.0.0-rc.0", features = ["serialization"] }
 futures = "0.3"
 hex = "0.4.3"
 kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "06dfda3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ed25519-dalek = { version = "2.1" }
 frost-ed25519 = { version = "1.0.0", features = ["serialization"] }
 futures = "0.3"
 hex = "0.4.3"
-kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "9d5eb1b" }
+kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "06dfda3" }
 minicbor = { version = "0.20", features = ["derive", "std"] }
 minicbor-io = { version = "0.15", features = ["async-io"] }
 num-bigint = "0.4"

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -157,6 +157,7 @@ sundaeswap:
     - token: SNEK
       unit: ADA
       asset_id: e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b.000de140cacb7fd5f5b84bf876d40dc60d4991c72112d78d76132b1fb769e6ad
+  retries: 3
 minswap:
   kupo_address: http://kupo:1442
   credential: e1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec13309/*
@@ -185,6 +186,7 @@ minswap:
     - token: SNEK
       unit: ADA
       asset_id: 0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1.63f2cbfa5bf8b68828839a2575c8c70f14a32f50ebbfa7c654043269793be896
+  retries: 3
 spectrum:
   kupo_address: http://kupo:1442
   credential: 6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69/*
@@ -207,3 +209,4 @@ spectrum:
     - token: SNEK
       unit: ADA
       asset_id: f8fd67ee46f66da669f68dc941090eb753687636b47fc6fd7f5e6254.534e454b5f4144415f4e4654
+  retries: 3

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -157,6 +157,7 @@ sundaeswap:
     - token: SNEK
       unit: ADA
       asset_id: e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b.000de140cacb7fd5f5b84bf876d40dc60d4991c72112d78d76132b1fb769e6ad
+  max_concurrency: 3
   retries: 3
 minswap:
   kupo_address: http://kupo:1442
@@ -186,6 +187,7 @@ minswap:
     - token: SNEK
       unit: ADA
       asset_id: 0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1.63f2cbfa5bf8b68828839a2575c8c70f14a32f50ebbfa7c654043269793be896
+  max_concurrency: 3
   retries: 3
 spectrum:
   kupo_address: http://kupo:1442
@@ -209,4 +211,5 @@ spectrum:
     - token: SNEK
       unit: ADA
       asset_id: f8fd67ee46f66da669f68dc941090eb753687636b47fc6fd7f5e6254.534e454b5f4144415f4e4654
+  max_concurrency: 3
   retries: 3

--- a/src/apis/kupo.rs
+++ b/src/apis/kupo.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use kupon::{Client, HealthStatus};
+use tokio::time::sleep;
+use tracing::{trace, warn};
+
+pub async fn wait_for_sync(client: &Client) {
+    let mut last_status = None;
+    loop {
+        let health = client.health().await;
+        let status_changed = !last_status.is_some_and(|s| s == health.status);
+        last_status = Some(health.status.clone());
+        match health.status {
+            HealthStatus::Healthy => return,
+            HealthStatus::Syncing => {
+                let status = health
+                    .info
+                    .map(|i| format!("syncing ({})", i.sync_progress()))
+                    .unwrap_or("syncing".into());
+                if status_changed {
+                    warn!(
+                        "Kupo server is {}. This source will be ignored until it is fully synced.",
+                        status
+                    );
+                } else {
+                    trace!("Kupo server is still {}.", status);
+                }
+                sleep(Duration::from_secs(1)).await;
+            }
+            HealthStatus::Disconnected => {
+                if status_changed {
+                    warn!("Kupo server is disconnected from the underlying node. Please check that it is configured correctly. This source will be ignored until kupo is connected and fully synced.")
+                } else {
+                    trace!("Kupo server is still disconnected from the underlying node.");
+                }
+                sleep(Duration::from_secs(5)).await;
+            }
+            HealthStatus::Error(reason) => {
+                if status_changed {
+                    warn!("Kupo server is unreachable or otherwise unhealthy: {}. Please ensure the server is running and configured correctly. This source will be ignored until it is.", reason);
+                } else {
+                    trace!("Kupo server is still unhealthy: {}", reason);
+                }
+                sleep(Duration::from_secs(10)).await;
+            }
+        }
+    }
+}

--- a/src/apis/kupo.rs
+++ b/src/apis/kupo.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use kupon::{Client, HealthStatus};
 use tokio::time::sleep;
-use tracing::{trace, warn};
+use tracing::{debug, warn};
 
 pub async fn wait_for_sync(client: &Client) {
     let mut last_status = None;
@@ -23,7 +23,7 @@ pub async fn wait_for_sync(client: &Client) {
                         status
                     );
                 } else {
-                    trace!("Kupo server is still {}.", status);
+                    debug!("Kupo server is still {}.", status);
                 }
                 sleep(Duration::from_secs(1)).await;
             }
@@ -31,7 +31,7 @@ pub async fn wait_for_sync(client: &Client) {
                 if status_changed {
                     warn!("Kupo server is disconnected from the underlying node. Please check that it is configured correctly. This source will be ignored until kupo is connected and fully synced.")
                 } else {
-                    trace!("Kupo server is still disconnected from the underlying node.");
+                    debug!("Kupo server is still disconnected from the underlying node.");
                 }
                 sleep(Duration::from_secs(5)).await;
             }
@@ -39,7 +39,7 @@ pub async fn wait_for_sync(client: &Client) {
                 if status_changed {
                     warn!("Kupo server is unreachable or otherwise unhealthy: {}. Please ensure the server is running and configured correctly. This source will be ignored until it is.", reason);
                 } else {
-                    trace!("Kupo server is still unhealthy: {}", reason);
+                    debug!("Kupo server is still unhealthy: {}", reason);
                 }
                 sleep(Duration::from_secs(10)).await;
             }

--- a/src/apis/kupo.rs
+++ b/src/apis/kupo.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use futures::{stream::FuturesUnordered, Future, StreamExt};
 use kupon::{Client, HealthStatus};
 use tokio::time::sleep;
 use tracing::{debug, warn};
@@ -44,5 +45,43 @@ pub async fn wait_for_sync(client: &Client) {
                 sleep(Duration::from_secs(10)).await;
             }
         }
+    }
+}
+
+/**
+ * Runs a set of futures, only allowing a certain number to execute at a time.
+ */
+pub struct MaxConcurrencyFutureSet<F: Future> {
+    running: FuturesUnordered<F>,
+    queued: Vec<F>,
+    concurrency: usize,
+}
+impl<F: Future> MaxConcurrencyFutureSet<F> {
+    pub fn new(concurrency: usize) -> Self {
+        assert!(concurrency > 0);
+        Self {
+            running: FuturesUnordered::new(),
+            queued: vec![],
+            concurrency,
+        }
+    }
+
+    pub fn push(&mut self, future: F) {
+        if self.running.len() < self.concurrency {
+            self.running.push(future);
+        } else {
+            self.queued.push(future);
+        }
+    }
+
+    pub async fn next(&mut self) -> Option<F::Output> {
+        let next = self.running.next().await;
+        if next.is_none() {
+            if let Some(another_task) = self.queued.pop() {
+                self.running.push(another_task);
+                return self.running.next().await;
+            }
+        }
+        next
     }
 }

--- a/src/apis/minswap.rs
+++ b/src/apis/minswap.rs
@@ -37,7 +37,9 @@ impl Source for MinswapSource {
 impl MinswapSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let minswap_config = &config.minswap;
-        let client = kupon::Builder::with_endpoint(&minswap_config.kupo_address).build()?;
+        let client = kupon::Builder::with_endpoint(&minswap_config.kupo_address)
+            .with_retries(minswap_config.retries)
+            .build()?;
         Ok(Self {
             client: Arc::new(client),
             credential: minswap_config.credential.clone(),

--- a/src/apis/minswap.rs
+++ b/src/apis/minswap.rs
@@ -9,7 +9,10 @@ use tracing::{warn, Instrument};
 
 use crate::config::{HydratedPool, OracleConfig};
 
-use super::source::{PriceInfo, PriceSink, Source};
+use super::{
+    kupo::wait_for_sync,
+    source::{PriceInfo, PriceSink, Source},
+};
 
 pub struct MinswapSource {
     client: Arc<kupon::Client>,
@@ -47,6 +50,8 @@ impl MinswapSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        wait_for_sync(&self.client).await;
+
         let mut set = JoinSet::new();
         for pool in &self.pools {
             let client = self.client.clone();

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,6 +1,7 @@
 pub mod binance;
 pub mod bybit;
 pub mod coinbase;
+pub mod kupo;
 pub mod maestro;
 pub mod minswap;
 pub mod source;

--- a/src/apis/spectrum.rs
+++ b/src/apis/spectrum.rs
@@ -37,7 +37,9 @@ impl Source for SpectrumSource {
 impl SpectrumSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let spectrum_config = &config.spectrum;
-        let client = kupon::Builder::with_endpoint(&spectrum_config.kupo_address).build()?;
+        let client = kupon::Builder::with_endpoint(&spectrum_config.kupo_address)
+            .with_retries(spectrum_config.retries)
+            .build()?;
         Ok(Self {
             client: Arc::new(client),
             credential: spectrum_config.credential.clone(),

--- a/src/apis/spectrum.rs
+++ b/src/apis/spectrum.rs
@@ -9,7 +9,10 @@ use tracing::{warn, Instrument};
 
 use crate::config::{HydratedPool, OracleConfig};
 
-use super::source::{PriceInfo, PriceSink, Source};
+use super::{
+    kupo::wait_for_sync,
+    source::{PriceInfo, PriceSink, Source},
+};
 
 pub struct SpectrumSource {
     client: Arc<kupon::Client>,
@@ -47,6 +50,8 @@ impl SpectrumSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        wait_for_sync(&self.client).await;
+
         let mut set = JoinSet::new();
         for pool in &self.pools {
             let client = self.client.clone();

--- a/src/apis/spectrum.rs
+++ b/src/apis/spectrum.rs
@@ -4,19 +4,20 @@ use anyhow::{anyhow, Result};
 use futures::{future::BoxFuture, FutureExt};
 use kupon::MatchOptions;
 use rust_decimal::Decimal;
-use tokio::{task::JoinSet, time::sleep};
+use tokio::time::sleep;
 use tracing::{warn, Instrument};
 
 use crate::config::{HydratedPool, OracleConfig};
 
 use super::{
-    kupo::wait_for_sync,
+    kupo::{wait_for_sync, MaxConcurrencyFutureSet},
     source::{PriceInfo, PriceSink, Source},
 };
 
 pub struct SpectrumSource {
     client: Arc<kupon::Client>,
     credential: String,
+    max_concurrency: usize,
     pools: Vec<Arc<HydratedPool>>,
 }
 
@@ -43,6 +44,7 @@ impl SpectrumSource {
         Ok(Self {
             client: Arc::new(client),
             credential: spectrum_config.credential.clone(),
+            max_concurrency: spectrum_config.max_concurrency,
             pools: config
                 .hydrate_pools(&spectrum_config.pools)
                 .into_iter()
@@ -54,7 +56,7 @@ impl SpectrumSource {
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
         wait_for_sync(&self.client).await;
 
-        let mut set = JoinSet::new();
+        let mut set = MaxConcurrencyFutureSet::new(self.max_concurrency);
         for pool in &self.pools {
             let client = self.client.clone();
             let sink = sink.clone();
@@ -64,7 +66,7 @@ impl SpectrumSource {
                 .asset_id(&pool.pool.asset_id)
                 .only_unspent();
 
-            set.spawn(
+            set.push(
                 async move {
                     let mut result = client.matches(&options).await?;
                     if result.is_empty() {
@@ -110,17 +112,13 @@ impl SpectrumSource {
             );
         }
 
-        while let Some(res) = set.join_next().await {
+        while let Some(res) = set.next().await {
             match res {
                 Err(error) => {
-                    // the task was cancelled or panicked
-                    warn!("error running spectrum query: {}", error);
-                }
-                Ok(Err(error)) => {
                     // the task ran, but returned an error
                     warn!("error querying spectrum: {}", error);
                 }
-                Ok(Ok(())) => {
+                Ok(()) => {
                     // all is well
                 }
             }

--- a/src/apis/sundaeswap_kupo.rs
+++ b/src/apis/sundaeswap_kupo.rs
@@ -43,7 +43,9 @@ impl Source for SundaeSwapKupoSource {
 impl SundaeSwapKupoSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let sundae_config = &config.sundaeswap;
-        let client = kupon::Builder::with_endpoint(&sundae_config.kupo_address).build()?;
+        let client = kupon::Builder::with_endpoint(&sundae_config.kupo_address)
+            .with_retries(sundae_config.retries)
+            .build()?;
         Ok(Self {
             client: Arc::new(client),
             credential: sundae_config.credential.clone(),

--- a/src/apis/sundaeswap_kupo.rs
+++ b/src/apis/sundaeswap_kupo.rs
@@ -14,7 +14,10 @@ use crate::{
     config::{HydratedPool, OracleConfig},
 };
 
-use super::source::{PriceSink, Source};
+use super::{
+    kupo::wait_for_sync,
+    source::{PriceSink, Source},
+};
 
 #[derive(Clone)]
 pub struct SundaeSwapKupoSource {
@@ -53,6 +56,8 @@ impl SundaeSwapKupoSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        wait_for_sync(&self.client).await;
+
         let mut set = JoinSet::new();
         for pool in &self.pools {
             let client = self.client.clone();

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -96,13 +96,13 @@ impl<C> Encode<C> for CborIdentifier {
         e: &mut Encoder<W>,
         ctx: &mut C,
     ) -> Result<(), encode::Error<W::Error>> {
-        let bytes: ByteArray<32> = self.0.serialize().into();
+        let bytes: ByteVec = self.0.serialize().into();
         bytes.encode(e, ctx)
     }
 }
 impl<'b, C> Decode<'b, C> for CborIdentifier {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        let bytes: ByteArray<32> = d.decode_with(ctx)?;
+        let bytes: ByteVec = d.decode_with(ctx)?;
         let value = Identifier::deserialize(&bytes).map_err(decode::Error::custom)?;
         Ok(Self(value))
     }
@@ -138,14 +138,14 @@ impl<C> Encode<C> for CborSignatureShare {
         e: &mut Encoder<W>,
         ctx: &mut C,
     ) -> Result<(), encode::Error<W::Error>> {
-        let bytes: ByteArray<32> = self.0.serialize().into();
+        let bytes: ByteVec = self.0.serialize().into();
         bytes.encode(e, ctx)
     }
 }
 impl<'b, C> Decode<'b, C> for CborSignatureShare {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        let bytes: ByteArray<32> = d.decode_with(ctx)?;
-        let value = SignatureShare::deserialize(*bytes).map_err(decode::Error::custom)?;
+        let bytes: ByteVec = d.decode_with(ctx)?;
+        let value = SignatureShare::deserialize(&bytes).map_err(decode::Error::custom)?;
         Ok(Self(value))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,7 @@ pub struct SundaeSwapConfig {
     pub credential: String,
     pub policy_id: String,
     pub pools: Vec<Pool>,
+    pub max_concurrency: usize,
     pub retries: usize,
 }
 
@@ -136,6 +137,7 @@ pub struct MinswapConfig {
     pub kupo_address: String,
     pub credential: String,
     pub pools: Vec<Pool>,
+    pub max_concurrency: usize,
     pub retries: usize,
 }
 
@@ -144,6 +146,7 @@ pub struct SpectrumConfig {
     pub kupo_address: String,
     pub credential: String,
     pub pools: Vec<Pool>,
+    pub max_concurrency: usize,
     pub retries: usize,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,7 @@ pub struct SundaeSwapConfig {
     pub credential: String,
     pub policy_id: String,
     pub pools: Vec<Pool>,
+    pub retries: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -135,6 +136,7 @@ pub struct MinswapConfig {
     pub kupo_address: String,
     pub credential: String,
     pub pools: Vec<Pool>,
+    pub retries: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -142,6 +144,7 @@ pub struct SpectrumConfig {
     pub kupo_address: String,
     pub credential: String,
     pub pools: Vec<Pool>,
+    pub retries: usize,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/health.rs
+++ b/src/health.rs
@@ -6,9 +6,12 @@ use tide::Response;
 use tokio::{sync::mpsc, task::JoinSet};
 use tracing::{info, warn, Instrument};
 
+use crate::network::{NetworkConfig, NodeId, Peer};
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Origin {
     Source(String),
+    Peer(NodeId),
 }
 
 pub struct HealthInfo {
@@ -22,13 +25,24 @@ pub enum HealthStatus {
 }
 
 type HealthSource = mpsc::UnboundedReceiver<HealthInfo>;
-type HealthMap = Arc<DashMap<Origin, HealthStatus>>;
+#[derive(Clone)]
+struct HealthState {
+    id: NodeId,
+    peers: Vec<Peer>,
+    statuses: Arc<DashMap<Origin, HealthStatus>>,
+}
 
 #[derive(Clone)]
-pub struct HealthSink(mpsc::UnboundedSender<HealthInfo>);
+pub struct HealthSink(Option<mpsc::UnboundedSender<HealthInfo>>);
 impl HealthSink {
+    pub fn noop() -> Self {
+        Self(None)
+    }
     pub fn update(&self, origin: Origin, status: HealthStatus) {
-        let result = self.0.send(HealthInfo {
+        let Some(sink) = self.0.as_ref() else {
+            return;
+        };
+        let result = sink.send(HealthInfo {
             origin: origin.clone(),
             status,
         });
@@ -40,16 +54,29 @@ impl HealthSink {
 
 pub struct HealthServer {
     source: HealthSource,
-    statuses: HealthMap,
+    state: HealthState,
 }
 impl HealthServer {
-    pub fn new() -> (Self, HealthSink) {
+    pub fn new(network_config: &NetworkConfig) -> (Self, HealthSink) {
         let (sink, source) = mpsc::unbounded_channel();
-        let sink = HealthSink(sink);
+        let statuses = Arc::new(DashMap::new());
+        let mut peers = network_config.peers.clone();
+        peers.sort_by_cached_key(|p| p.label.clone());
+        for peer in &peers {
+            statuses.insert(
+                Origin::Peer(peer.id.clone()),
+                HealthStatus::Unhealthy("Not yet connected".into()),
+            );
+        }
+        let sink = HealthSink(Some(sink));
         (
             Self {
                 source,
-                statuses: Arc::new(DashMap::new()),
+                state: HealthState {
+                    id: network_config.id.clone(),
+                    peers,
+                    statuses,
+                },
             },
             sink,
         )
@@ -59,7 +86,7 @@ impl HealthServer {
         let mut set = JoinSet::new();
 
         let mut source = self.source;
-        let statuses = self.statuses.clone();
+        let statuses = self.state.statuses.clone();
         set.spawn(
             async move {
                 while let Some(info) = source.recv().await {
@@ -69,7 +96,7 @@ impl HealthServer {
             .in_current_span(),
         );
 
-        let mut app = tide::with_state(self.statuses);
+        let mut app = tide::with_state(self.state);
         app.at("/health").get(report_health);
         set.spawn(
             async move {
@@ -90,22 +117,74 @@ impl HealthServer {
 }
 
 #[derive(Serialize)]
+enum PeerConnectionStatus {
+    Connected,
+    WaitingForIncomingConnection,
+    TryingToConnect,
+}
+
+#[derive(Serialize)]
+struct PeerStatus {
+    pub name: String,
+    pub id: NodeId,
+    pub address: String,
+    pub connection: PeerConnectionStatus,
+}
+
+#[derive(Serialize)]
 struct ServerHealth {
+    pub id: NodeId,
     pub healthy: bool,
+    pub peers: Vec<PeerStatus>,
     pub errors: HashMap<String, String>,
 }
 
-async fn report_health(req: tide::Request<HealthMap>) -> tide::Result {
+async fn report_health(req: tide::Request<HealthState>) -> tide::Result {
     let mut errors = HashMap::new();
-    for entry in req.state().iter() {
+    let state = req.state();
+    for entry in state.statuses.iter() {
         let (origin, status) = entry.pair();
         if let HealthStatus::Unhealthy(reason) = status {
-            errors.insert(format!("{:?}", origin), reason.clone());
+            let label = match origin {
+                Origin::Source(name) => name.to_string(),
+                Origin::Peer(id) => state
+                    .peers
+                    .iter()
+                    .find(|n| n.id == *id)
+                    .map_or_else(|| format!("{}", id), |p| p.label.clone()),
+            };
+            errors.insert(label, reason.clone());
         }
     }
 
+    let peers = state
+        .peers
+        .iter()
+        .map(|p| {
+            let connected = state
+                .statuses
+                .get(&Origin::Peer(p.id.clone()))
+                .is_some_and(|s| matches!(s.value(), HealthStatus::Healthy));
+            let status = if connected {
+                PeerConnectionStatus::Connected
+            } else if state.id.should_initiate_connection_to(&p.id) {
+                PeerConnectionStatus::TryingToConnect
+            } else {
+                PeerConnectionStatus::WaitingForIncomingConnection
+            };
+            PeerStatus {
+                name: p.label.clone(),
+                id: p.id.clone(),
+                address: p.address.clone(),
+                connection: status,
+            }
+        })
+        .collect();
+
     let health = ServerHealth {
+        id: state.id.clone(),
         healthy: errors.is_empty(),
+        peers,
         errors,
     };
     let status = if health.healthy { 200 } else { 503 };

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -52,7 +52,7 @@ pub fn write_frost_keys(
     public_key: PublicKeyPackage,
 ) -> Result<String> {
     let verifying_key = public_key.verifying_key();
-    let address = compute_address(&verifying_key.serialize())?;
+    let address = compute_address(&verifying_key.serialize()?)?;
     let frost_key_path = keys_dir.join(&address);
     fs::create_dir_all(&frost_key_path)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,8 @@ impl Node {
         // quorum is set to a majority of expected nodes (which includes ourself!)
         let quorum = ((network_config.peers.len() + 1) / 2) + 1;
 
-        let (health_server, health_sink) = HealthServer::new(&network_config);
+        let (leader_tx, leader_rx) = watch::channel(RaftLeader::Unknown);
+        let (health_server, health_sink) = HealthServer::new(&network_config, leader_rx.clone());
 
         // Construct a peer-to-peer network that can connect to peers, and dispatch messages to the correct state machine
         let mut network = Network::new(&network_config, health_sink.clone());
@@ -57,8 +58,6 @@ impl Node {
         let (pa_tx, pa_rx) = watch::channel(vec![]);
 
         let price_aggregator = PriceAggregator::new(pa_tx, config.clone())?;
-
-        let (leader_tx, leader_rx) = watch::channel(RaftLeader::Unknown);
 
         let (result_tx, result_rx) = mpsc::channel(10);
 

--- a/src/network/config.rs
+++ b/src/network/config.rs
@@ -1,0 +1,79 @@
+use std::fs;
+
+use anyhow::{Context, Result};
+use ed25519::{
+    pkcs8::{DecodePrivateKey, DecodePublicKey},
+    KeypairBytes, PublicKeyBytes,
+};
+use ed25519_dalek::{SigningKey as PrivateKey, VerifyingKey as PublicKey};
+use tracing::info;
+
+use crate::{
+    config::{OracleConfig, PeerConfig},
+    keys,
+};
+
+use super::NodeId;
+
+pub struct NetworkConfig {
+    pub id: NodeId,
+    pub private_key: PrivateKey,
+    pub port: u16,
+    pub peers: Vec<Peer>,
+}
+
+impl NetworkConfig {
+    pub fn load(config: &OracleConfig) -> Result<Self> {
+        let private_key = read_private_key()?;
+        let id = compute_node_id(&private_key.verifying_key());
+        info!("This node has ID {}", id);
+
+        let peers: Result<Vec<Peer>> = config.peers.iter().map(parse_peer).collect();
+        let mut peers: Vec<Peer> = peers?.into_iter().filter(|p| p.id != id).collect();
+        peers.sort_by_cached_key(|k| k.id.clone());
+        Ok(Self {
+            id,
+            private_key,
+            port: config.port,
+            peers,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct Peer {
+    pub id: NodeId,
+    pub public_key: PublicKey,
+    pub label: String,
+    pub address: String,
+}
+
+fn parse_peer(config: &PeerConfig) -> Result<Peer> {
+    let public_key = {
+        let key_bytes = PublicKeyBytes::from_public_key_pem(&config.public_key)?;
+        PublicKey::from_bytes(&key_bytes.0)?
+    };
+    let id = compute_node_id(&public_key);
+    let label = config.label.as_ref().unwrap_or(&config.address).clone();
+    Ok(Peer {
+        id,
+        public_key,
+        label,
+        address: config.address.clone(),
+    })
+}
+
+fn read_private_key() -> Result<PrivateKey> {
+    let key_path = keys::get_keys_directory()?.join("private.pem");
+    let key_pem_file = fs::read_to_string(&key_path).context(format!(
+        "Could not load private key from {}",
+        key_path.display()
+    ))?;
+    let decoded = KeypairBytes::from_pkcs8_pem(&key_pem_file)?;
+    let private_key = PrivateKey::from_bytes(&decoded.secret_key);
+    Ok(private_key)
+}
+
+pub fn compute_node_id(public_key: &PublicKey) -> NodeId {
+    NodeId::new(hex::encode(public_key.as_bytes()))
+}

--- a/src/network/types.rs
+++ b/src/network/types.rs
@@ -11,6 +11,9 @@ impl NodeId {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
     }
+    pub fn should_initiate_connection_to(&self, other: &NodeId) -> bool {
+        self < other
+    }
 }
 impl Display for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -496,17 +496,17 @@ impl Signer {
         let mut signatures = vec![];
         for (package, sigs) in packages.iter().zip(signature_maps) {
             let signature = aggregate(package, &sigs, &self.public_key)?;
-            signatures.push(signature);
+            signatures.push(signature.serialize()?);
         }
 
         let payload = price_data
             .iter()
             .zip(signatures)
-            .map(|(price, sig)| SignedPriceFeedEntry {
+            .map(|(price, signature)| SignedPriceFeedEntry {
                 price: price.price,
                 data: SignedPriceFeed {
                     data: price.data.clone(),
-                    signature: sig.serialize().into(),
+                    signature,
                 },
             })
             .collect();


### PR DESCRIPTION
- Make all kupo-backed sources wait for the kupo instance to be healthy (i.e. indexing is fully caught up) before trying to report pricesfrom it.
- Configure kupo client to retry (with expotential backoff and jitter) if too many requests are reaching it at once.
- Limit how many concurrent queries each kupo-backed source runs at any given time. By default, only run 3 at a time per peer.
- Update health endpoint with details about peers, including their current connection statuses and which node is the current raft leader.
- Pull a bunch of config parsing code out of the networking core and into a shared structure, so the health endpoint can reuse it.
- Upgrade frost-ed25519 to a new release candidate, to avoid a vuln in the current release