### PR TITLE
Use cargo-chef and build caches to speed up docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,10 +35,28 @@ jobs:
         with:
           images: sundaeswap/butane-oracle
 
+      - name: Cargo Build Cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: cargo-build-cache
+          key: ${{ runner.os }}-cargo-build-cache
+
+      - name: inject cargo-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@5b6db76d1da5c8b307d5d2e0706d266521b710de # v3.1.2
+        with:
+          cache-map: |
+            {
+              "cargo-build-cache": "/usr/local/cargo/registry"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: .
           file: ./Dockerfile
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,19 +35,22 @@ jobs:
         with:
           images: sundaeswap/butane-oracle
 
-      - name: Cargo Build Cache
+      - name: Cargo Cache
         id: cache
         uses: actions/cache@v4
         with:
-          path: cargo-build-cache
-          key: ${{ runner.os }}-cargo-build-cache
+          path: |
+            cargo-registry-cache
+            sccache-cache
+          key: ${{ runner.os }}-cargo-cache
 
-      - name: inject cargo-build-cache into docker
+      - name: inject cargo caches into docker
         uses: reproducible-containers/buildkit-cache-dance@5b6db76d1da5c8b307d5d2e0706d266521b710de # v3.1.2
         with:
           cache-map: |
             {
-              "cargo-build-cache": "/usr/local/cargo/registry"
+              "cargo-registry-cache": "/usr/local/cargo/registry",
+              "sccache-cache": "/sccache"
             }
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,9 +2366,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallas-codec"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea50feb0c8f87b5ee38df90ed3c125d7f7ecd81a7fe1eafc1a90931dd127590"
+checksum = "756a3880d93394fdf3ff99fdf66e3af11b3ec78fcb41f531912914dd4538f8ca"
 dependencies = [
  "hex",
  "minicbor",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5705ee695a2429d8a352af62671cc3470ba5f76fd48968b59bc6c049ef75a7e0"
+checksum = "2ff8e22df6e7e9f9eb4cd32740cd3f9622ca01f6803c2628330aab1a552437b9"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0476fed841261c33a0fcba321bd69961c3d392eba50821dc0e64808439c71aa"
+checksum = "4c0db2643e5bdb09e69470bf1f4a29375aa5ddabba77f405c64f2b694459dc9e"
 dependencies = [
  "base58",
  "bech32 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ minicbor = { version = "0.20", features = ["derive", "std"] }
 minicbor-io = { version = "0.15", features = ["async-io"] }
 num-bigint = "0.4"
 num-integer = "0.1"
-pallas-crypto = "0.27"
-pallas-primitives = "0.27"
+pallas-crypto = "0.28.0"
+pallas-primitives = "0.28.0"
 rand = "0.8.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rust_decimal = "1.34.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
-FROM rust:alpine AS build
-RUN apk add musl-dev openssl-dev openssl-libs-static
-ENV OPENSSL_STATIC=1
-WORKDIR /build
-COPY src /build/src
-COPY Cargo.toml Cargo.lock config.base.yaml /build/
-RUN cargo build --release
+FROM lukemathwalker/cargo-chef:latest-rust-alpine as chef
+WORKDIR /app
+RUN apk add musl-dev
+
+FROM chef AS planner
+COPY src /app/src
+COPY Cargo.toml Cargo.lock config.base.yaml /app/
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo chef cook --release --recipe-path recipe.json
+COPY src /app/src
+COPY Cargo.toml Cargo.lock config.base.yaml /app/
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+  cargo build --release --bin oracles
 
 FROM alpine
 WORKDIR /app
-COPY --from=build /build/target/release/oracles /app/
+COPY --from=builder /app/target/release/oracles /app/
 CMD ["./oracles"]


### PR DESCRIPTION
cargo-chef lets you download/build all dependencies in a separate docker layer from the one that builds your project, so docker can just reuse that layer if deps don't change.

Build caches I think let us skip downloading crates, giving a little speed boost.