### PR TITLE
Add tests and several bugfixes for raft logic

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1,356 +1,20 @@
-use std::{collections::HashSet, ops::Sub};
+mod logic;
+#[cfg(test)]
+mod tests;
 
-use minicbor::{Decode, Encode};
-use rand::Rng;
-use tokio::sync::watch;
-use tracing::{info, trace, warn};
+use tokio::{sync::watch, time::Instant};
+use tracing::{info, trace};
 
-use crate::network::{IncomingMessage, Network, NetworkChannel, NodeId};
+use crate::network::{Network, NetworkChannel, NodeId};
 
-#[derive(Decode, Encode, Debug, Clone)]
-pub enum RaftMessage {
-    #[n(0)]
-    Connect,
-    #[n(1)]
-    Disconnect,
-    #[n(2)]
-    RequestVote {
-        #[n(0)]
-        term: usize,
-    },
-    #[n(3)]
-    RequestVoteResponse {
-        #[n(0)]
-        term: usize,
-        #[n(1)]
-        vote: bool,
-    },
-    #[n(4)]
-    Heartbeat {
-        #[n(0)]
-        term: usize,
-    },
-}
-
-#[derive(Eq, PartialEq, Clone)]
-pub enum RaftStatus {
-    Follower {
-        leader: Option<NodeId>,
-        voted_for: Option<NodeId>,
-    },
-    Candidate {
-        votes: usize,
-    },
-    Leader,
-}
-
-#[derive(Eq, PartialEq, Clone, Debug)]
-pub enum RaftLeader {
-    Myself,
-    Other(NodeId),
-    Unknown,
-}
-
-pub struct RaftState {
-    pub id: NodeId,
-    pub quorum: usize,
-    pub peers: HashSet<NodeId>,
-    warned_about_quorum: bool,
-
-    pub last_heartbeat: std::time::Instant,
-    pub heartbeat_freq: std::time::Duration,
-    pub timeout_freq: std::time::Duration,
-    pub jitter: std::time::Duration,
-
-    pub status: RaftStatus,
-    pub term: usize,
-
-    pub leader_sink: watch::Sender<RaftLeader>,
-}
+use logic::RaftState;
+pub use logic::{RaftLeader, RaftMessage};
 
 pub struct Raft {
     pub id: NodeId,
 
     channel: NetworkChannel<RaftMessage>,
     state: RaftState,
-}
-
-impl RaftState {
-    pub fn new(
-        id: NodeId,
-        quorum: usize,
-        heartbeat_freq: std::time::Duration,
-        timeout_freq: std::time::Duration,
-        leader_sink: watch::Sender<RaftLeader>,
-    ) -> Self {
-        RaftState {
-            id,
-            quorum,
-            warned_about_quorum: false,
-            peers: HashSet::new(),
-            last_heartbeat: std::time::Instant::now(),
-            heartbeat_freq,
-            timeout_freq,
-            jitter: std::time::Duration::from_millis(rand::thread_rng().gen_range(50..100)),
-            status: RaftStatus::Follower {
-                leader: None,
-                voted_for: None,
-            },
-            term: 0,
-            leader_sink,
-        }
-    }
-
-    pub fn leader(&self) -> Option<NodeId> {
-        match &self.status {
-            RaftStatus::Leader => Some(self.id.clone()),
-            RaftStatus::Follower {
-                leader: Some(leader),
-                ..
-            } => Some(leader.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn is_leader(&self) -> bool {
-        matches!(self.status, RaftStatus::Leader)
-    }
-
-    pub fn receive(
-        &mut self,
-        timestamp: std::time::Instant,
-        message: IncomingMessage<RaftMessage>,
-    ) -> Vec<(NodeId, RaftMessage)> {
-        let from = message.from;
-        match &message.data {
-            RaftMessage::Connect => {
-                info!("New peer {}", from);
-                self.peers.insert(from.clone());
-                if matches!(self.status, RaftStatus::Leader) {
-                    // Let them know right away that we're the leader
-                    let response = RaftMessage::Heartbeat { term: self.term };
-                    vec![(from.clone(), response)]
-                } else {
-                    vec![]
-                }
-            }
-            RaftMessage::Disconnect => {
-                info!("Peer disconnected {}", from);
-                self.peers.remove(&from);
-                if self.peers.len() < self.quorum - 1 {
-                    info!("Too few peers connected, raft status unknown");
-                    self.clear_status();
-                }
-                vec![]
-            }
-            RaftMessage::Heartbeat { term } => {
-                let current_leader = self.leader();
-                if *term >= self.term {
-                    self.term = *term;
-                    self.set_status(RaftStatus::Follower {
-                        leader: Some(from.clone()),
-                        voted_for: None,
-                    });
-                    if Some(from.clone()) != current_leader {
-                        info!(term = term, leader = %from, "New leader");
-                    }
-                    self.warned_about_quorum = false;
-                }
-                self.last_heartbeat = timestamp;
-                vec![]
-            }
-            RaftMessage::RequestVote {
-                term: requested_term,
-            } => {
-                trace!(term = requested_term, "Vote requested by {}", from);
-                let peer = from.clone();
-                let (vote, reason) = match self.status {
-                    RaftStatus::Follower {
-                        leader: _,
-                        voted_for: Some(_),
-                    } => (false, "Already voted"),
-                    RaftStatus::Leader
-                    | RaftStatus::Follower {
-                        leader: _,
-                        voted_for: None,
-                    } => {
-                        if *requested_term > self.term {
-                            // Vote for the candidate
-                            let current_leader = match &self.status {
-                                RaftStatus::Follower {
-                                    leader,
-                                    voted_for: _,
-                                } => leader.clone(),
-                                RaftStatus::Leader => Some(self.id.clone()),
-                                RaftStatus::Candidate { .. } => None,
-                            };
-                            self.set_status(RaftStatus::Follower {
-                                leader: current_leader,
-                                voted_for: Some(from.clone()),
-                            });
-                            (true, "newer term with note vote")
-                        } else {
-                            (false, "old term")
-                        }
-                    }
-                    RaftStatus::Candidate { .. } => {
-                        if *requested_term > self.term {
-                            self.set_status(RaftStatus::Follower {
-                                leader: None,
-                                voted_for: Some(from.clone()),
-                            });
-                            (true, "newer term with vote")
-                        } else {
-                            (false, "already voted for self")
-                        }
-                    }
-                };
-                trace!(
-                    term = requested_term,
-                    reason = reason,
-                    vote = vote,
-                    "Casting vote for {}'s election",
-                    peer
-                );
-                let response = RaftMessage::RequestVoteResponse {
-                    term: *requested_term,
-                    vote,
-                };
-                vec![(peer, response)]
-            }
-            RaftMessage::RequestVoteResponse { term, vote, .. } => {
-                match self.status {
-                    RaftStatus::Candidate { votes: prev_votes } => {
-                        if *term != self.term {
-                            return vec![];
-                        }
-                        if !vote {
-                            trace!(
-                                votes = prev_votes,
-                                term = term,
-                                my_term = self.term,
-                                quorum = self.quorum,
-                                "Vote rejected"
-                            );
-                            return vec![];
-                        }
-
-                        let new_votes = prev_votes + 1;
-                        trace!(votes = new_votes, quorum = self.quorum, "Vote received");
-                        self.set_status(RaftStatus::Candidate { votes: new_votes });
-                        if new_votes >= self.quorum {
-                            info!(
-                                term = term,
-                                votes = new_votes,
-                                quorum = self.quorum,
-                                "Election won"
-                            );
-                            self.set_status(RaftStatus::Leader);
-                            // Immediately send a heartbeat to make leader election stable
-                            return self
-                                .peers
-                                .iter()
-                                .map(|peer| (peer.clone(), RaftMessage::Heartbeat { term: *term }))
-                                .collect();
-                        } else {
-                            vec![]
-                        }
-                    }
-                    _ => {
-                        if *term >= self.term {
-                            warn!(term = term, from = %from, "Unexpected message {:?}", message.data);
-                        }
-                        vec![]
-                    }
-                }
-            }
-        }
-    }
-
-    pub fn tick(&mut self, timestamp: std::time::Instant) -> Vec<(NodeId, RaftMessage)> {
-        let actual_timeout = self.timeout_freq.sub(self.jitter);
-        let is_leader = self.is_leader();
-        let elapsed_time = timestamp.duration_since(self.last_heartbeat);
-        let heartbeat_timeout = elapsed_time > self.heartbeat_freq;
-        let election_timeout = elapsed_time > actual_timeout;
-        let can_reach_quorum = (self.peers.len() + 1) >= self.quorum;
-
-        if election_timeout && !can_reach_quorum {
-            if !self.warned_about_quorum {
-                warn!(
-                    term = self.term,
-                    nodes = self.peers.len() + 1,
-                    quorum = self.quorum,
-                    "Timeout (with leader) reached after {:?}, but can't reach quorum",
-                    actual_timeout
-                );
-                self.warned_about_quorum = true;
-            }
-            vec![]
-        } else if election_timeout && can_reach_quorum {
-            info!(
-                term = self.term + 1,
-                nodes = self.peers.len() + 1,
-                quorum = self.quorum,
-                last_heartbeat = format!("{:?}", self.last_heartbeat),
-                "Timeout reached after {:?}, starting a new election",
-                actual_timeout
-            );
-            // Update jitter to avoid aggressive election cycles
-            self.jitter = std::time::Duration::from_millis((rand::random::<u8>() % 50 + 50) as u64);
-
-            // Start an election
-            self.set_status(RaftStatus::Candidate { votes: 1 });
-            self.term += 1;
-            self.last_heartbeat = timestamp;
-
-            return self
-                .peers
-                .iter()
-                .map(|peer| (peer.clone(), RaftMessage::RequestVote { term: self.term }))
-                .collect();
-        } else if is_leader && heartbeat_timeout {
-            if !self.peers.is_empty() {
-                trace!("Sending heartbeats as leader");
-                // Send heartbeats
-                self.last_heartbeat = timestamp;
-                self.peers
-                    .iter()
-                    .map(|peer| (peer.clone(), RaftMessage::Heartbeat { term: self.term }))
-                    .collect()
-            } else {
-                vec![]
-            }
-        } else {
-            vec![]
-        }
-    }
-
-    fn clear_status(&mut self) {
-        self.set_status(RaftStatus::Follower {
-            leader: None,
-            voted_for: None,
-        });
-    }
-
-    fn set_status(&mut self, status: RaftStatus) {
-        let leader = match &status {
-            RaftStatus::Leader => RaftLeader::Myself,
-            RaftStatus::Follower {
-                leader: Some(leader),
-                ..
-            } => RaftLeader::Other(leader.clone()),
-            _ => RaftLeader::Unknown,
-        };
-        self.status = status;
-        self.leader_sink.send_if_modified(|old_leader| {
-            let changed = *old_leader != leader;
-            if changed {
-                *old_leader = leader;
-            }
-            changed
-        });
-    }
 }
 
 impl Raft {
@@ -371,6 +35,7 @@ impl Raft {
         let channel = network.raft_channel();
         let state = RaftState::new(
             id.clone(),
+            Instant::now(),
             quorum,
             heartbeat_freq,
             timeout_freq,
@@ -380,12 +45,11 @@ impl Raft {
     }
 
     pub async fn handle_messages(self) {
-        info!("testing");
         let (sender, mut receiver) = self.channel.split();
         let mut state = self.state;
         loop {
             let next_message = receiver.try_recv().await;
-            let timestamp = std::time::Instant::now();
+            let timestamp = Instant::now();
 
             let responses = match next_message {
                 Some(msg) => {

--- a/src/raft/logic.rs
+++ b/src/raft/logic.rs
@@ -1,0 +1,377 @@
+use std::{collections::BTreeSet, ops::Sub};
+
+use minicbor::{Decode, Encode};
+use rand::Rng;
+use tokio::{
+    sync::watch,
+    time::{Duration, Instant},
+};
+use tracing::{info, trace, warn};
+
+use crate::network::{IncomingMessage, NodeId};
+
+#[derive(Decode, Encode, Debug, Clone, PartialEq, Eq)]
+pub enum RaftMessage {
+    #[n(0)]
+    Connect,
+    #[n(1)]
+    Disconnect,
+    #[n(2)]
+    RequestVote {
+        #[n(0)]
+        term: usize,
+    },
+    #[n(3)]
+    RequestVoteResponse {
+        #[n(0)]
+        term: usize,
+        #[n(1)]
+        vote: bool,
+    },
+    #[n(4)]
+    Heartbeat {
+        #[n(0)]
+        term: usize,
+    },
+}
+
+#[derive(Eq, PartialEq, Clone)]
+pub enum RaftStatus {
+    Follower {
+        leader: Option<NodeId>,
+        voted_for: Option<NodeId>,
+    },
+    Candidate {
+        votes: BTreeSet<NodeId>,
+    },
+    Leader,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub enum RaftLeader {
+    Myself,
+    Other(NodeId),
+    Unknown,
+}
+
+pub struct RaftState {
+    pub id: NodeId,
+    pub quorum: usize,
+    pub peers: BTreeSet<NodeId>,
+    warned_about_quorum: bool,
+
+    pub last_event: Instant,
+    pub heartbeat_freq: Duration,
+    pub timeout_freq: Duration,
+    pub jitter: Duration,
+
+    pub status: RaftStatus,
+    pub term: usize,
+
+    pub leader_sink: watch::Sender<RaftLeader>,
+}
+
+impl RaftState {
+    pub fn new(
+        id: NodeId,
+        start_time: Instant,
+        quorum: usize,
+        heartbeat_freq: Duration,
+        timeout_freq: Duration,
+        leader_sink: watch::Sender<RaftLeader>,
+    ) -> Self {
+        RaftState {
+            id,
+            quorum,
+            warned_about_quorum: false,
+            peers: BTreeSet::new(),
+            last_event: start_time,
+            heartbeat_freq,
+            timeout_freq,
+            jitter: Duration::from_millis(rand::thread_rng().gen_range(50..100)),
+            status: RaftStatus::Follower {
+                leader: None,
+                voted_for: None,
+            },
+            term: 0,
+            leader_sink,
+        }
+    }
+
+    fn leader(&self) -> Option<NodeId> {
+        match &self.status {
+            RaftStatus::Leader => Some(self.id.clone()),
+            RaftStatus::Follower {
+                leader: Some(leader),
+                ..
+            } => Some(leader.clone()),
+            _ => None,
+        }
+    }
+
+    fn is_leader(&self) -> bool {
+        matches!(self.status, RaftStatus::Leader)
+    }
+
+    pub fn receive(
+        &mut self,
+        timestamp: Instant,
+        message: IncomingMessage<RaftMessage>,
+    ) -> Vec<(NodeId, RaftMessage)> {
+        let from = message.from;
+        match &message.data {
+            RaftMessage::Connect => {
+                info!("New peer {}", from);
+                self.peers.insert(from.clone());
+                if matches!(self.status, RaftStatus::Leader) {
+                    // Let them know right away that we're the leader
+                    let response = RaftMessage::Heartbeat { term: self.term };
+                    vec![(from.clone(), response)]
+                } else {
+                    vec![]
+                }
+            }
+            RaftMessage::Disconnect => {
+                info!("Peer disconnected {}", from);
+                self.peers.remove(&from);
+                if self.peers.len() < self.quorum - 1 {
+                    info!("Too few peers connected, raft status unknown");
+                    self.clear_status();
+                } else if self.leader() == Some(from) {
+                    info!("Current leader has disconnected");
+                    self.clear_status();
+                }
+                vec![]
+            }
+            RaftMessage::Heartbeat { term } => {
+                let current_leader = self.leader();
+                if *term >= self.term {
+                    self.term = *term;
+                    self.set_status(RaftStatus::Follower {
+                        leader: Some(from.clone()),
+                        voted_for: None,
+                    });
+                    if Some(from.clone()) != current_leader {
+                        info!(term = term, leader = %from, "New leader");
+                    }
+                    self.warned_about_quorum = false;
+                }
+                self.last_event = timestamp;
+                vec![]
+            }
+            RaftMessage::RequestVote {
+                term: requested_term,
+            } => {
+                trace!(term = requested_term, "Vote requested by {}", from);
+                let peer = from.clone();
+                let is_new_term = *requested_term > self.term;
+                let (vote, reason) = if is_new_term {
+                    self.term = *requested_term;
+                    (true, "First candidate of new term")
+                } else {
+                    match &self.status {
+                        RaftStatus::Leader => (false, "Already elected self"),
+                        RaftStatus::Follower {
+                            leader: _,
+                            voted_for: Some(candidate),
+                        } => {
+                            if candidate == &from {
+                                (true, "Already voted for this candidate")
+                            } else {
+                                (false, "Already voted for another candidate")
+                            }
+                        }
+                        RaftStatus::Follower {
+                            leader: _,
+                            voted_for: None,
+                        } => (true, "First candidate of term"),
+                        RaftStatus::Candidate { .. } => (false, "Already voted for self"),
+                    }
+                };
+
+                trace!(
+                    term = requested_term,
+                    reason = reason,
+                    vote = vote,
+                    "Casting vote for {}'s election",
+                    peer
+                );
+                if vote {
+                    let mut leader = None;
+                    let mut old_voted_for = None;
+                    if let RaftStatus::Follower {
+                        leader: current_leader,
+                        voted_for,
+                    } = &self.status
+                    {
+                        old_voted_for.clone_from(voted_for);
+                        if !is_new_term {
+                            leader.clone_from(current_leader);
+                        }
+                    };
+                    if !old_voted_for.is_some_and(|id| id == from) {
+                        // If we're newly voting for someone, reset the election timeout
+                        self.last_event = timestamp;
+                    }
+                    self.set_status(RaftStatus::Follower {
+                        leader,
+                        voted_for: Some(from.clone()),
+                    });
+                }
+                let response = RaftMessage::RequestVoteResponse {
+                    term: self.term,
+                    vote,
+                };
+                vec![(peer, response)]
+            }
+            RaftMessage::RequestVoteResponse { term, vote, .. } => {
+                match &self.status {
+                    RaftStatus::Candidate { votes: prev_votes } => {
+                        if *term < self.term {
+                            return vec![];
+                        }
+                        if *term > self.term {
+                            trace!(
+                                term = term,
+                                my_term = self.term,
+                                "Updating to match peer's newer term"
+                            );
+                            self.term = *term;
+                        }
+                        if !vote {
+                            trace!(
+                                votes = prev_votes.len(),
+                                term,
+                                quorum = self.quorum,
+                                "Vote rejected"
+                            );
+                            return vec![];
+                        }
+
+                        let mut new_votes = prev_votes.clone();
+                        new_votes.insert(from.clone());
+                        trace!(
+                            votes = new_votes.len(),
+                            term,
+                            quorum = self.quorum,
+                            "Vote received"
+                        );
+                        self.set_status(RaftStatus::Candidate {
+                            votes: new_votes.clone(),
+                        });
+                        if new_votes.len() >= self.quorum {
+                            info!(
+                                term = term,
+                                votes = new_votes.len(),
+                                quorum = self.quorum,
+                                "Election won"
+                            );
+                            self.set_status(RaftStatus::Leader);
+                            // Immediately send a heartbeat to make leader election stable
+                            return self
+                                .peers
+                                .iter()
+                                .map(|peer| (peer.clone(), RaftMessage::Heartbeat { term: *term }))
+                                .collect();
+                        } else {
+                            vec![]
+                        }
+                    }
+                    _ => {
+                        if *term >= self.term {
+                            warn!(term = term, from = %from, "Unexpected message {:?}", message.data);
+                        }
+                        vec![]
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn tick(&mut self, timestamp: Instant) -> Vec<(NodeId, RaftMessage)> {
+        let actual_timeout = self.timeout_freq.sub(self.jitter);
+        let is_leader = self.is_leader();
+        let elapsed_time = timestamp.duration_since(self.last_event);
+        let heartbeat_timeout = elapsed_time > self.heartbeat_freq;
+        let election_timeout = elapsed_time > actual_timeout;
+        let can_reach_quorum = (self.peers.len() + 1) >= self.quorum;
+
+        if election_timeout && !can_reach_quorum {
+            if !self.warned_about_quorum {
+                warn!(
+                    term = self.term,
+                    nodes = self.peers.len() + 1,
+                    quorum = self.quorum,
+                    "Timeout (with leader) reached after {:?}, but can't reach quorum",
+                    actual_timeout
+                );
+                self.warned_about_quorum = true;
+            }
+            vec![]
+        } else if election_timeout && can_reach_quorum {
+            info!(
+                term = self.term + 1,
+                nodes = self.peers.len() + 1,
+                quorum = self.quorum,
+                ?self.last_event,
+                "Timeout reached after {:?}, starting a new election",
+                actual_timeout
+            );
+            // Update jitter to avoid aggressive election cycles
+            self.jitter = Duration::from_millis((rand::random::<u8>() % 50 + 50) as u64);
+
+            // Start an election
+            let mut votes = BTreeSet::new();
+            votes.insert(self.id.clone());
+            self.set_status(RaftStatus::Candidate { votes });
+            self.term += 1;
+            self.last_event = timestamp;
+
+            return self
+                .peers
+                .iter()
+                .map(|peer| (peer.clone(), RaftMessage::RequestVote { term: self.term }))
+                .collect();
+        } else if is_leader && heartbeat_timeout {
+            if !self.peers.is_empty() {
+                trace!("Sending heartbeats as leader");
+                // Send heartbeats
+                self.last_event = timestamp;
+                self.peers
+                    .iter()
+                    .map(|peer| (peer.clone(), RaftMessage::Heartbeat { term: self.term }))
+                    .collect()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        }
+    }
+
+    fn clear_status(&mut self) {
+        self.set_status(RaftStatus::Follower {
+            leader: None,
+            voted_for: None,
+        });
+    }
+
+    fn set_status(&mut self, status: RaftStatus) {
+        let leader = match &status {
+            RaftStatus::Leader => RaftLeader::Myself,
+            RaftStatus::Follower {
+                leader: Some(leader),
+                ..
+            } => RaftLeader::Other(leader.clone()),
+            _ => RaftLeader::Unknown,
+        };
+        self.status = status;
+        self.leader_sink.send_if_modified(|old_leader| {
+            let changed = *old_leader != leader;
+            if changed {
+                *old_leader = leader;
+            }
+            changed
+        });
+    }
+}

--- a/src/raft/tests.rs
+++ b/src/raft/tests.rs
@@ -1,0 +1,646 @@
+use std::array;
+
+use tokio::{
+    sync::watch,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    network::{IncomingMessage, NodeId},
+    raft::{logic::RaftState, RaftLeader, RaftMessage},
+};
+
+#[tokio::test]
+async fn should_elect_self_as_leader() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    // Once a single node votes for us, we have reached a quorum of 2 and are the leader
+    assert_eq!(
+        state.receive(
+            &other_id1,
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        ),
+        [
+            (other_id1.clone(), RaftMessage::Heartbeat { term: 1 }),
+            (other_id2.clone(), RaftMessage::Heartbeat { term: 1 }),
+        ]
+    );
+
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+}
+
+#[tokio::test]
+async fn should_not_count_false_votes() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    // If a node refuses to connect to us, we shouldn't count their vote
+    assert_eq!(
+        state.receive(
+            &other_id1,
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: false
+            }
+        ),
+        vec![]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+}
+
+#[tokio::test]
+async fn should_not_double_count_votes_from_one_node() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2, other_id3], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id3, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(
+        peers,
+        vec![other_id1.clone(), other_id2.clone(), other_id3.clone()]
+    );
+    assert_eq!(term, 1);
+
+    // With four nodes, we need 3 votes (including our own) to reach quorum.
+    // One node voting for us is not enough.
+    assert_eq!(
+        state.receive(
+            &other_id1,
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        ),
+        vec![]
+    );
+    // The same node voting twice is still not enough.
+    assert_eq!(
+        state.receive(
+            &other_id1,
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        ),
+        vec![]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+}
+
+#[tokio::test]
+async fn should_vote_for_other_node() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    // We vote for the first candidate who asks us to
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        )]
+    );
+}
+
+#[tokio::test]
+async fn should_not_vote_twice_in_one_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    // We vote for the first candidate who asks us to
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        )]
+    );
+    // We DON'T vote for the second
+    assert_eq!(
+        state.receive(&other_id2, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id2.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: false
+            }
+        )]
+    );
+}
+
+#[tokio::test]
+async fn should_vote_again_for_second_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    // We vote for the first candidate who asks us to
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        )]
+    );
+    // But if someone else comes along with a newer term, vote for them instead
+    assert_eq!(
+        state.receive(&other_id2, RaftMessage::RequestVote { term: 10 }),
+        vec![(
+            other_id2.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 10,
+                vote: true
+            }
+        )]
+    );
+}
+
+#[tokio::test]
+async fn should_return_new_term_when_vote_requested_for_older_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    // get ourself onto a high term number
+    state.become_follower(&other_id1, 1000);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Disconnect), vec![]);
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+
+    // If a candidate on an older term asks for a vote, we should respond with our actual term
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1000,
+                vote: true
+            }
+        )]
+    );
+}
+
+#[tokio::test]
+async fn should_update_term_when_vote_received_for_newer_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    assert_eq!(
+        state.receive(
+            &other_id2,
+            RaftMessage::RequestVoteResponse {
+                term: 1000,
+                vote: true
+            }
+        ),
+        vec![
+            (other_id1.clone(), RaftMessage::Heartbeat { term: 1000 }),
+            (other_id2.clone(), RaftMessage::Heartbeat { term: 1000 }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn should_update_term_when_false_vote_received_for_newer_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    assert_eq!(
+        state.receive(
+            &other_id2,
+            RaftMessage::RequestVoteResponse {
+                term: 1000,
+                vote: false
+            }
+        ),
+        vec![]
+    );
+
+    let (_, next_term) = state.begin_election();
+    assert_eq!(next_term, 1001);
+}
+
+#[tokio::test]
+async fn should_respond_idempotently_to_request_for_vote() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    // Voting for the first node
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        )]
+    );
+    // Even if they ask more than once
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 1 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 1,
+                vote: true
+            }
+        )]
+    );
+}
+
+#[tokio::test]
+async fn should_renounce_leadership_when_vote_requested_from_newer_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    state.become_leader();
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 100 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 100,
+                vote: true
+            }
+        )]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+}
+
+#[tokio::test]
+async fn should_consider_other_node_leader_when_heartbeat_received() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::Heartbeat { term: 1 }),
+        vec![]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Other(other_id1));
+}
+
+#[tokio::test]
+async fn should_renounce_leadership_when_quorum_lost() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    state.become_leader();
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+
+    // Disconnecting from one node does not make us lose quorum
+    assert_eq!(state.receive(&other_id2, RaftMessage::Disconnect), vec![]);
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+
+    // But disconnecting from a second node does
+    assert_eq!(state.receive(&other_id1, RaftMessage::Disconnect), vec![]);
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+}
+
+#[tokio::test]
+async fn should_renounce_leadership_when_heartbeat_received_from_node_with_higher_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    state.become_leader();
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::Heartbeat { term: 9001 }),
+        vec![]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Other(other_id1));
+}
+
+#[tokio::test]
+async fn should_ignore_leader_heartbeats_from_lower_term() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    state.become_follower(&other_id1, 9001);
+    assert_eq!(
+        leader_source.borrow().clone(),
+        RaftLeader::Other(other_id1.clone())
+    );
+
+    assert_eq!(
+        state.receive(&other_id2, RaftMessage::Heartbeat { term: 1337 }),
+        vec![]
+    );
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Other(other_id1));
+}
+
+#[tokio::test]
+async fn should_notify_new_nodes_when_we_are_leader() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+
+    state.become_leader();
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Myself);
+
+    assert_eq!(
+        state.receive(&other_id2, RaftMessage::Connect),
+        vec![(other_id2.clone(), RaftMessage::Heartbeat { term: 1 })]
+    );
+}
+
+#[tokio::test]
+async fn should_forget_current_leader_if_they_disconnect() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], leader_source) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    state.become_follower(&other_id1, 2);
+    assert_eq!(
+        leader_source.borrow().clone(),
+        RaftLeader::Other(other_id1.clone())
+    );
+
+    assert_eq!(state.receive(&other_id1, RaftMessage::Disconnect), vec![]);
+    assert_eq!(leader_source.borrow().clone(), RaftLeader::Unknown);
+}
+
+#[tokio::test]
+async fn should_start_new_election_if_current_election_times_out() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    assert_eq!(
+        state.tick(timeout_freq),
+        vec![
+            (other_id1.clone(), RaftMessage::RequestVote { term: 2 }),
+            (other_id2.clone(), RaftMessage::RequestVote { term: 2 }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn should_reset_new_election_timeout_after_voting() {
+    let start_time = Instant::now();
+    let heartbeat_freq = Duration::from_millis(1000);
+    let timeout_freq = Duration::from_millis(2000);
+
+    let (mut state, [other_id1, other_id2], _) =
+        generate_state(start_time, heartbeat_freq, timeout_freq);
+    assert_eq!(state.receive(&other_id1, RaftMessage::Connect), vec![]);
+    assert_eq!(state.receive(&other_id2, RaftMessage::Connect), vec![]);
+
+    let (peers, term) = state.begin_election();
+    assert_eq!(peers, vec![other_id1.clone(), other_id2.clone()]);
+    assert_eq!(term, 1);
+
+    // run for a while, but not long enough to time out
+    assert_eq!(
+        state.tick(timeout_freq / 2 + Duration::from_millis(500)),
+        vec![]
+    );
+    // Oh, we voted before the timeout hit
+    assert_eq!(
+        state.receive(&other_id1, RaftMessage::RequestVote { term: 20 }),
+        vec![(
+            other_id1.clone(),
+            RaftMessage::RequestVoteResponse {
+                term: 20,
+                vote: true
+            }
+        )]
+    );
+
+    // now we run for long enough to trigger the old timeout, and confirm it didn't get triggered
+    assert_eq!(state.tick(timeout_freq / 2), vec![]);
+    // but if we run for a little longer, we hit the timeout and start a new election
+    assert_eq!(
+        state.tick(timeout_freq / 2),
+        vec![
+            (other_id1.clone(), RaftMessage::RequestVote { term: 21 }),
+            (other_id2.clone(), RaftMessage::RequestVote { term: 21 }),
+        ]
+    );
+}
+
+fn generate_state<const N: usize>(
+    start_time: Instant,
+    heartbeat_freq: Duration,
+    timeout_freq: Duration,
+) -> (Participant, [NodeId; N], watch::Receiver<RaftLeader>) {
+    let (leader_sink, leader_source) = watch::channel(RaftLeader::Unknown);
+    let quorum = ((N + 1) / 2) + 1;
+    let my_id = NodeId::new("me".into());
+    let participant = Participant {
+        now: start_time,
+        timeout_freq,
+        state: RaftState::new(
+            my_id,
+            start_time,
+            quorum,
+            heartbeat_freq,
+            timeout_freq,
+            leader_sink,
+        ),
+    };
+    let other_ids = array::from_fn(|idx| NodeId::new(idx.to_string()));
+    (participant, other_ids, leader_source)
+}
+
+struct Participant {
+    now: Instant,
+    timeout_freq: Duration,
+    state: RaftState,
+}
+impl Participant {
+    pub fn receive(&mut self, from: &NodeId, message: RaftMessage) -> Vec<(NodeId, RaftMessage)> {
+        self.now += Duration::from_millis(1);
+        self.state.receive(
+            self.now,
+            IncomingMessage {
+                from: from.clone(),
+                data: message,
+            },
+        )
+    }
+
+    pub fn tick(&mut self, duration: Duration) -> Vec<(NodeId, RaftMessage)> {
+        self.now += duration;
+        self.state.tick(self.now)
+    }
+
+    pub fn begin_election(&mut self) -> (Vec<NodeId>, usize) {
+        // "run" for long enough to start another election
+        let begin_election_messages = self.tick(self.timeout_freq);
+        if begin_election_messages.is_empty() {
+            panic!("We tried initiating an election, but failed");
+        }
+        let mut peers = vec![];
+        let mut term = 0;
+        for (from, message) in begin_election_messages {
+            let RaftMessage::RequestVote { term: t } = message else {
+                panic!("We tried initiating an election, but failed");
+            };
+            peers.push(from);
+            term = t;
+        }
+        (peers, term)
+    }
+
+    pub fn become_leader(&mut self) {
+        // "run" for long enough to start another election
+        let (peers, term) = self.begin_election();
+        for peer in peers {
+            // have the others vote for us until we are leader
+            let heartbeat_messages =
+                self.receive(&peer, RaftMessage::RequestVoteResponse { term, vote: true });
+            if !heartbeat_messages.is_empty() {
+                // We know that we are the leader if we sent out heartbeats to every other node
+                assert!(heartbeat_messages
+                    .iter()
+                    .all(|(_, message)| matches!(message, RaftMessage::Heartbeat { .. })));
+                return;
+            }
+        }
+        panic!("Failed to become leader");
+    }
+
+    pub fn become_follower(&mut self, new_leader: &NodeId, term: usize) {
+        assert_eq!(
+            self.receive(new_leader, RaftMessage::Heartbeat { term }),
+            vec![]
+        );
+    }
+}


### PR DESCRIPTION
Bugs bashed:

- Fix leader tracking.
  - If the leader disconnects, immediately forget that they are the leader.
  - Fix an edge case where the current leader thought it was a follower of itself during elections.
- If we voted in a term when no leader was elected, vote again in later terms. This allows the system to recover from conflicts.
- Handle duplicate messages gracefully.
  - If we receive two RequestVotes for the same candidate in the same term, respond true twice.
  - If we receive two RequestVoteResponses from the same peer in the same term, do not count their vote twice.
- If we request a vote from a node in a newer term, increase our term to match theirs. This lets newly started/restarted nodes catch up to the rest of the cluster before quorum is achieved.
- When we vote affirmatively, reset our timeout. If we have a 2000ms timeout and we received a vote request at 1900ms, there's no point in voting and then immediately giving up and starting a new election.