### PR TITLE
Network ping

### DIFF
--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -593,7 +593,7 @@ impl Core {
     ) {
         let them = peer.label.clone();
         info!(them, "Connected to {}", peer.id);
-        self.report_healthy_connection(&peer.id);
+        self.report_healthy_connection(&peer.id, &peer_version);
 
         // try to tell Raft that we are definitely connected
         let _ = self
@@ -718,10 +718,11 @@ impl Core {
             .try_send((peer.id.clone(), AppMessage::Raft(RaftMessage::Disconnect)));
     }
 
-    fn report_healthy_connection(&self, peer: &NodeId) {
+    fn report_healthy_connection(&self, peer: &NodeId, version: &str) {
         let origin = Origin::Peer(peer.clone());
         let status = HealthStatus::Healthy;
         self.health_sink.update(origin, status);
+        self.health_sink.track_peer_version(peer, version);
     }
 
     fn report_unhealthy_connection(&self, peer: &NodeId, reason: &str) {


### PR DESCRIPTION
Servers now ping each other every 5 seconds, and if they don't get a response in time they disconnect from the peer.

We skip this for nodes running version 0.7, so that we can roll this out without getting everyone to upgrade at the same time.

Also, since we have to track the other server's version anyway, report it in the health endpoint.