### PR TITLE
Make Raft more resilient to bad network conditions

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -130,10 +130,10 @@ impl Network {
 }
 
 fn create_channel<T>(holder: &mut Option<MpscPair<T>>) -> NetworkChannel<T> {
-    let (outgoing_tx, outgoing_rx) = mpsc::channel(10);
+    let (outgoing_tx, outgoing_rx) = mpsc::channel(2000);
     let sender = NetworkSender::new(outgoing_tx);
 
-    let (incoming_tx, incoming_rx) = mpsc::channel(10);
+    let (incoming_tx, incoming_rx) = mpsc::channel(2000);
     let receiver = NetworkReceiver::new(incoming_rx);
 
     holder.replace((incoming_tx, outgoing_rx));


### PR DESCRIPTION
The other day, we saw failures where not every node recognized the leader after a round of Raft. Our working theory is that this was caused by nodes dropping raft Connect/Disconnect messages because their channels filled up.

This isn't a complete fix for that problem, but it should work around it in practice and I can come back with a real fix next week or so. I want to get a log aggregator going before spending too much time debugging.

- Raise the capacity of "fallible" channels (where we drop messages instead of blocking when they're full) from 10 messages to 2000. Doesn't fix anything, but should make dropping messages less likely.
- Make the network layer block when publishing Connect/Disconnect messages to the "incoming message" channel. That didn't used to be safe, but it is now (because the _consumers_ of that channel drop messages when full).