### PR TITLE
Sg/instrumentation improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +888,16 @@ name = "fiat-crypto"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2896,6 +2915,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ minicbor-io = { version = "0.15", features = ["async-io"] }
 num-bigint = "0.4"
 num-integer = "0.1"
 opentelemetry = "0.24"
-opentelemetry-otlp = { version = "0.17", features = ["tls-webpki-roots"] }
+opentelemetry-otlp = { version = "0.17", features = ["gzip-tonic", "tls-webpki-roots"] }
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }
 pallas-crypto = "0.29"
 pallas-primitives = "0.29"

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -83,7 +83,10 @@ fn init_providers(
     uptrace_dsn: Option<&String>,
 ) -> Result<(trace::TracerProvider, metrics::SdkMeterProvider)> {
     global::set_error_handler(|error| {
-        tracing::error!("OpenTelemetry error occurred: {:#}", anyhow::anyhow!(error),);
+        let span = tracing::info_span!("opentelemetry_error_handler");
+        span.in_scope(|| {
+            tracing::error!("OpenTelemetry error occurred: {:#}", anyhow::anyhow!(error));
+        });
     })?;
 
     let resource = Resource::default().merge(&Resource::new([

--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -160,6 +160,7 @@ impl ExporterProvider {
     fn get(&self) -> TonicExporterBuilder {
         opentelemetry_otlp::new_exporter()
             .tonic()
+            .with_compression(opentelemetry_otlp::Compression::Gzip)
             .with_endpoint(&self.endpoint)
             .with_timeout(Duration::from_secs(5))
             .with_tls_config(ClientTlsConfig::new().with_webpki_roots())

--- a/src/network/core.rs
+++ b/src/network/core.rs
@@ -721,7 +721,7 @@ impl Core {
             warn!(them, disconnect_reason, "disconnecting from peer");
             disconnect_tx.send_replace(disconnect_reason);
         }
-        .instrument(info_span!("process", "otel.kind" = "consumer"));
+        .instrument(info_span!("process_network", "otel.kind" = "consumer"));
 
         join!(send_task, process_task);
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -3,7 +3,7 @@ mod logic;
 mod tests;
 
 use tokio::{sync::watch, time::Instant};
-use tracing::{info, trace};
+use tracing::{debug, info};
 
 use crate::network::{Network, NetworkChannel, NodeId};
 
@@ -55,7 +55,7 @@ impl Raft {
                 Some(msg) => {
                     let span = msg.span.clone();
                     let _x = span.enter();
-                    trace!("Received message: {:?}", msg);
+                    debug!("Received message: {:?}", msg);
                     state.receive(timestamp, msg)
                 }
                 None => state.tick(timestamp),

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2,8 +2,12 @@ mod logic;
 #[cfg(test)]
 mod tests;
 
-use tokio::{sync::watch, time::Instant};
-use tracing::{debug, info};
+use tokio::{
+    select,
+    sync::watch,
+    time::{sleep_until, Instant},
+};
+use tracing::{debug, info, info_span};
 
 use crate::network::{Network, NetworkChannel, NodeId};
 
@@ -48,25 +52,26 @@ impl Raft {
         let (sender, mut receiver) = self.channel.split();
         let mut state = self.state;
         loop {
-            let next_message = receiver.try_recv().await;
-            let timestamp = Instant::now();
-
-            let responses = match next_message {
-                Some(msg) => {
+            let next_event = state.next_event(Instant::now());
+            let responses = select! {
+                Some(msg) = receiver.recv() => {
                     let span = msg.span.clone();
-                    let _x = span.enter();
-                    debug!("Received message: {:?}", msg);
-                    state.receive(timestamp, msg)
-                }
-                None => state.tick(timestamp),
+                    span.in_scope(|| {
+                        debug!("Received message: {:?}", msg);
+                        state.receive(Instant::now(), msg)
+                    })
+                },
+                _ = sleep_until(next_event) => {
+                    let span = info_span!("raft_tick");
+                    span.in_scope(|| {
+                        state.tick(next_event)
+                    })
+                },
             };
-
             // Send out any responses
             for (peer, response) in responses {
                 sender.send(peer, response).await;
             }
-            // Yield back to the scheduler, so that other tasks can run
-            tokio::task::yield_now().await;
         }
     }
 }

--- a/src/raft/logic.rs
+++ b/src/raft/logic.rs
@@ -6,7 +6,7 @@ use tokio::{
     sync::watch,
     time::{Duration, Instant},
 };
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, warn};
 
 use crate::network::{IncomingMessage, NodeId};
 
@@ -164,7 +164,7 @@ impl RaftState {
             RaftMessage::RequestVote {
                 term: requested_term,
             } => {
-                trace!(term = requested_term, "Vote requested by {}", from);
+                debug!(term = requested_term, "Vote requested by {}", from);
                 let peer = from.clone();
                 let is_new_term = *requested_term > self.term;
                 let (vote, reason) = if is_new_term {
@@ -191,7 +191,7 @@ impl RaftState {
                     }
                 };
 
-                trace!(
+                debug!(
                     term = requested_term,
                     reason = reason,
                     vote = vote,
@@ -233,15 +233,15 @@ impl RaftState {
                             return vec![];
                         }
                         if *term > self.term {
-                            trace!(
-                                term = term,
+                            debug!(
+                                term,
                                 my_term = self.term,
                                 "Updating to match peer's newer term"
                             );
                             self.term = *term;
                         }
                         if !vote {
-                            trace!(
+                            debug!(
                                 votes = prev_votes.len(),
                                 term,
                                 quorum = self.quorum,
@@ -252,7 +252,7 @@ impl RaftState {
 
                         let mut new_votes = prev_votes.clone();
                         new_votes.insert(from.clone());
-                        trace!(
+                        debug!(
                             votes = new_votes.len(),
                             term,
                             quorum = self.quorum,
@@ -337,7 +337,7 @@ impl RaftState {
         } else if is_leader && heartbeat_timeout {
             self.emit_has_leader(true);
             if !self.peers.is_empty() {
-                trace!("Sending heartbeats as leader");
+                debug!("Sending heartbeats as leader");
                 // Send heartbeats
                 self.last_event = timestamp;
                 self.peers

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -259,7 +259,7 @@ impl Signer {
         }
     }
 
-    #[instrument(skip_all, fields(round = self.state.round(), state = %self.state))]
+    #[instrument(name = "process_signer", skip_all, fields(round = self.state.round(), state = %self.state))]
     pub async fn process(&mut self, event: SignerEvent) {
         info!("Started event: {}", event);
         match self.do_process(event.clone()).await {


### PR DESCRIPTION
* Log opentelemetry errors in their own scope, so they are more likely to reach uptrace
* Bump raft logs from trace to debug
* Make the context hashmap optional in application messages (makes connection errors less noisy while waiting for folks to upgrade)
* Rename some spans (hard to tell what "process" does at a glance)
* Add spans to timeout-triggered raft events
* Make the raft state machine sleep while waiting for the next event, instead of polling for it (so that timeout-triggered raft spans don't overwhelm opentelemetry)