### PR TITLE
Clean up logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ async fn main() -> Result<()> {
     let config = Arc::new(load_config(&args.config_file)?);
 
     let _guard = instrumentation::init_tracing(&config.logs)?;
-    info_span!("init").in_scope(|| info!(foo = "bar", "Node starting..."));
+    info_span!("init").in_scope(|| info!("Node starting..."));
 
     if config.keygen.enabled {
         dkg::run(&config).await?;

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -140,7 +140,8 @@ impl PriceAggregator {
             debug!(
                 collateral_name,
                 synthetic_name = synth.name,
-                histogram.collateral_price = price
+                histogram.collateral_price = price,
+                "price metrics",
             );
         }
 
@@ -151,6 +152,7 @@ impl PriceAggregator {
         PriceFeedEntry {
             price: synth_price,
             data: PriceFeed {
+                collateral_names: Some(synth.collateral.clone()),
                 collateral_prices,
                 synthetic: synth.name.clone(),
                 denominator,

--- a/src/price_feed.rs
+++ b/src/price_feed.rs
@@ -83,6 +83,7 @@ impl<'b, C> Decode<'b, C> for SignedPriceFeed {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PriceFeed {
+    pub collateral_names: Option<Vec<String>>,
     pub collateral_prices: Vec<BigUint>,
     pub synthetic: String,
     pub denominator: BigUint,
@@ -131,6 +132,7 @@ impl<'b, C> Decode<'b, C> for PriceFeed {
         decode_struct_end(d)?;
 
         Ok(PriceFeed {
+            collateral_names: None,
             collateral_prices,
             synthetic,
             denominator,
@@ -362,7 +364,9 @@ mod tests {
 
     #[test]
     fn should_serialize_price_feed() {
+        // Note: the only thing that doesn't round trip is collateral_names
         let feed = PriceFeed {
+            collateral_names: None,
             collateral_prices: vec![BigUint::from(1u32), BigUint::from(u128::MAX) * 2u32],
             synthetic: "HIPI".into(),
             denominator: BigUint::from(31337u32),

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -116,7 +116,8 @@ impl SignatureAggregator {
                     if let Ok(age_in_millis) = u64::try_from(age.as_millis()) {
                         debug!(
                             histogram.payload_age = age_in_millis,
-                            histogram.payload_is_valid = is_valid
+                            histogram.payload_is_valid = is_valid,
+                            "payload metrics"
                         );
                     }
                 }

--- a/src/signature_aggregator/price_comparator.rs
+++ b/src/signature_aggregator/price_comparator.rs
@@ -92,12 +92,7 @@ mod tests {
         denominator: u64,
     ) -> PriceFeed {
         PriceFeed {
-            collateral_names: Some(
-                collateral_names
-                    .into_iter()
-                    .map(|&s| s.to_string())
-                    .collect(),
-            ),
+            collateral_names: Some(collateral_names.iter().map(|&s| s.to_string()).collect()),
             collateral_prices: collateral_prices
                 .iter()
                 .map(|&p| BigUint::from(p))

--- a/src/signature_aggregator/price_comparator.rs
+++ b/src/signature_aggregator/price_comparator.rs
@@ -31,10 +31,17 @@ fn should_sign(leader_feed: &PriceFeed, my_feed: &PriceFeed) -> Result<(), Strin
         ));
     }
     // If one price is >1% less than the other, they're too distant to trust
-    for (leader_price, my_price) in leader_feed
+    for ((leader_price, my_price), collateral) in leader_feed
         .collateral_prices
         .iter()
         .zip(my_feed.collateral_prices.iter())
+        .zip(
+            my_feed
+                .collateral_names
+                .as_ref()
+                .expect("my feed should always have collateral names")
+                .iter(),
+        )
     {
         let leader_value = leader_price * &my_feed.denominator;
         let my_value = my_price * &leader_feed.denominator;
@@ -43,8 +50,13 @@ fn should_sign(leader_feed: &PriceFeed, my_feed: &PriceFeed) -> Result<(), Strin
         let difference = &max_value - min_value;
         if difference * 100u32 > max_value {
             return Err(format!(
-                "collateral prices are too distant: leader has {}/{}, we have {}/{}",
-                leader_price, leader_feed.denominator, my_price, my_feed.denominator
+                "collateral prices ({} per {}) are too distant: leader has {}/{}, we have {}/{}",
+                leader_feed.synthetic,
+                collateral,
+                leader_price,
+                leader_feed.denominator,
+                my_price,
+                my_feed.denominator
             ));
         }
     }
@@ -73,8 +85,19 @@ mod tests {
     use super::should_sign_all;
     use crate::price_feed::{IntervalBound, PriceFeed, Validity};
 
-    fn price_feed(synthetic: &str, collateral_prices: &[u64], denominator: u64) -> PriceFeed {
+    fn price_feed(
+        synthetic: &str,
+        collateral_names: &[&str],
+        collateral_prices: &[u64],
+        denominator: u64,
+    ) -> PriceFeed {
         PriceFeed {
+            collateral_names: Some(
+                collateral_names
+                    .into_iter()
+                    .map(|&s| s.to_string())
+                    .collect(),
+            ),
             collateral_prices: collateral_prices
                 .iter()
                 .map(|&p| BigUint::from(p))
@@ -87,16 +110,16 @@ mod tests {
 
     #[test]
     fn should_sign_close_enough_collateral_prices() {
-        let leader_feed = vec![price_feed("TOKEN", &[2], 1)];
-        let my_feed = vec![price_feed("TOKEN", &[199], 100)];
+        let leader_feed = vec![price_feed("SYNTH", &["COLL"], &[2], 1)];
+        let my_feed = vec![price_feed("SYNTH", &["COLL"], &[199], 100)];
 
         assert!(should_sign_all(&leader_feed, &my_feed).is_ok());
     }
 
     #[test]
     fn should_not_sign_distant_collateral_prices() {
-        let leader_feed = vec![price_feed("TOKEN", &[2], 1)];
-        let my_feed = vec![price_feed("TOKEN", &[3], 2)];
+        let leader_feed = vec![price_feed("SYNTH", &["COLL"], &[2], 1)];
+        let my_feed = vec![price_feed("SYNTH", &["COLL"], &[3], 2)];
 
         assert!(should_sign_all(&leader_feed, &my_feed).is_err());
     }
@@ -104,12 +127,12 @@ mod tests {
     #[test]
     fn should_sign_close_enough_validity() {
         const TIMESTAMP: u64 = 1712723729359;
-        let mut leader_price = price_feed("TOKEN", &[1], 1);
+        let mut leader_price = price_feed("SYNTH", &["COLL"], &[1], 1);
         leader_price.validity = Validity {
             lower_bound: IntervalBound::unix_timestamp(TIMESTAMP, true),
             upper_bound: IntervalBound::unix_timestamp(TIMESTAMP + 3000000, true),
         };
-        let mut my_price = price_feed("TOKEN", &[1], 1);
+        let mut my_price = price_feed("SYNTH", &["COLL"], &[1], 1);
         my_price.validity = Validity {
             lower_bound: IntervalBound::unix_timestamp(TIMESTAMP + 5000, true),
             upper_bound: IntervalBound::unix_timestamp(TIMESTAMP + 3005000, true),
@@ -121,12 +144,12 @@ mod tests {
     #[test]
     fn should_not_sign_distant_validity() {
         const TIMESTAMP: u64 = 1712723729359;
-        let mut leader_price = price_feed("TOKEN", &[1], 1);
+        let mut leader_price = price_feed("SYNTH", &["COLL"], &[1], 1);
         leader_price.validity = Validity {
             lower_bound: IntervalBound::unix_timestamp(TIMESTAMP, true),
             upper_bound: IntervalBound::unix_timestamp(TIMESTAMP + 3000000, true),
         };
-        let mut my_price = price_feed("TOKEN", &[1], 1);
+        let mut my_price = price_feed("SYNTH", &["COLL"], &[1], 1);
         my_price.validity = Validity {
             lower_bound: IntervalBound::unix_timestamp(TIMESTAMP + 5000000, true),
             upper_bound: IntervalBound::unix_timestamp(TIMESTAMP + 8000000, true),

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -840,12 +840,14 @@ mod tests {
     fn price_feed_entry(
         synthetic: &str,
         price: f64,
+        collateral_names: &[&str],
         collateral_prices: &[u64],
         denominator: u64,
     ) -> PriceFeedEntry {
         PriceFeedEntry {
             price: Decimal::from_f64(price).unwrap(),
             data: PriceFeed {
+                collateral_names: Some(collateral_names.iter().map(|&s| s.to_string()).collect()),
                 collateral_prices: collateral_prices
                     .iter()
                     .map(|&p| BigUint::from(p))
@@ -860,8 +862,8 @@ mod tests {
     #[tokio::test]
     async fn should_sign_payload_with_quorum_of_two() -> Result<()> {
         let price_data = vec![
-            price_feed_entry("ADA", 3.50, &[3, 4], 1),
-            price_feed_entry("BTN", 1.21, &[5, 8], 1),
+            price_feed_entry("ADA", 3.50, &["A", "B"], &[3, 4], 1),
+            price_feed_entry("BTN", 1.21, &["A", "B"], &[5, 8], 1),
         ];
 
         let prices = vec![price_data.clone(); 3];
@@ -910,8 +912,8 @@ mod tests {
     #[tokio::test]
     async fn should_sign_payload_with_quorum_of_three() -> Result<()> {
         let price_data = vec![
-            price_feed_entry("ADA", 3.50, &[3, 4], 1),
-            price_feed_entry("BTN", 1.21, &[5, 8], 1),
+            price_feed_entry("ADA", 3.50, &["A", "B"], &[3, 4], 1),
+            price_feed_entry("BTN", 1.21, &["A", "B"], &[5, 8], 1),
         ];
 
         let (mut signers, mut network, mut payload_source) =
@@ -926,8 +928,8 @@ mod tests {
 
     #[tokio::test]
     async fn should_sign_close_enough_collateral_prices() -> Result<()> {
-        let leader_prices = vec![price_feed_entry("TOKEN", 3.50, &[2], 1)];
-        let follower_prices = vec![price_feed_entry("TOKEN", 3.50, &[199], 100)];
+        let leader_prices = vec![price_feed_entry("SYNTH", 3.50, &["A"], &[2], 1)];
+        let follower_prices = vec![price_feed_entry("SYNTH", 3.50, &["A"], &[199], 100)];
 
         let (mut signers, mut network, mut payload_source) =
             construct_signers(2, vec![leader_prices, follower_prices]).await?;
@@ -941,8 +943,8 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_sign_distant_collateral_prices() -> Result<()> {
-        let leader_prices = vec![price_feed_entry("TOKEN", 3.50, &[2], 1)];
-        let follower_prices = vec![price_feed_entry("TOKEN", 3.50, &[3], 2)];
+        let leader_prices = vec![price_feed_entry("SYNTH", 3.50, &["A"], &[2], 1)];
+        let follower_prices = vec![price_feed_entry("SYNTH", 3.50, &["A"], &[3], 2)];
 
         let (mut signers, mut network, mut payload_source) =
             construct_signers(2, vec![leader_prices, follower_prices]).await?;


### PR DESCRIPTION
Cleans up some of the logs; in particular, includes synthetic and collateral prices for the refuse-to-sign logs