### PR TITLE
[SB-1894] Let nodes sign some price feeds, instead of signing everything or nothing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ impl Node {
         let (signature_aggregator, payload_source) = if config.consensus {
             SignatureAggregator::consensus(&config, &mut network, price_feed_rx, leader_rx)?
         } else {
-            SignatureAggregator::single(&network.id, price_feed_rx, leader_rx)?
+            SignatureAggregator::single(&config, price_feed_rx, leader_rx)?
         };
 
         let api_server = APIServer::new(&config, payload_source.clone(), price_audit_rx);

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -3,10 +3,14 @@ pub mod price_comparator;
 pub mod signer;
 pub mod single_aggregator;
 
-use std::time::{Duration, SystemTime};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use anyhow::Result;
 use consensus_aggregator::ConsensusSignatureAggregator;
+use dashmap::DashMap;
 use minicbor::Encoder;
 use pallas_primitives::conway::PlutusData;
 use serde::Serialize;
@@ -21,12 +25,13 @@ use tracing::debug;
 use crate::{
     config::OracleConfig,
     network::{Network, NodeId},
-    price_feed::{IntervalBoundType, PriceFeedEntry, SignedEntries},
+    price_feed::{IntervalBoundType, PriceFeedEntry, SignedEntries, SignedEntry},
     raft::RaftLeader,
 };
 
 pub struct SignatureAggregator {
     implementation: SignatureAggregatorImplementation,
+    synthetics: Vec<String>,
     signed_entries_source: mpsc::Receiver<(NodeId, SignedEntries)>,
     payload_sink: watch::Sender<Payload>,
 }
@@ -37,22 +42,28 @@ enum SignatureAggregatorImplementation {
 
 impl SignatureAggregator {
     pub fn single(
-        id: &NodeId,
+        config: &OracleConfig,
         price_source: watch::Receiver<Vec<PriceFeedEntry>>,
         leader_source: watch::Receiver<RaftLeader>,
     ) -> Result<(Self, watch::Receiver<Payload>)> {
+        let synthetics = config.synthetics.iter().map(|s| s.name.clone()).collect();
         let (signed_entries_sink, signed_entries_source) = mpsc::channel(10);
         let (payload_sink, mut payload_source) = watch::channel(Payload {
-            publisher: id.clone(),
+            publisher: config.id.clone(),
             timestamp: SystemTime::now(),
             entries: vec![],
         });
         payload_source.mark_unchanged();
 
-        let aggregator =
-            SingleSignatureAggregator::new(id, price_source, leader_source, signed_entries_sink)?;
+        let aggregator = SingleSignatureAggregator::new(
+            &config.id,
+            price_source,
+            leader_source,
+            signed_entries_sink,
+        )?;
         let aggregator = SignatureAggregator {
             implementation: SignatureAggregatorImplementation::Single(aggregator),
+            synthetics,
             signed_entries_source,
             payload_sink,
         };
@@ -65,6 +76,7 @@ impl SignatureAggregator {
         price_source: watch::Receiver<Vec<PriceFeedEntry>>,
         leader_source: watch::Receiver<RaftLeader>,
     ) -> Result<(Self, watch::Receiver<Payload>)> {
+        let synthetics = config.synthetics.iter().map(|s| s.name.clone()).collect();
         let (signed_entries_sink, signed_entries_source) = mpsc::channel(10);
         let (payload_sink, mut payload_source) = watch::channel(Payload {
             publisher: network.id.clone(),
@@ -82,6 +94,7 @@ impl SignatureAggregator {
         )?;
         let aggregator = SignatureAggregator {
             implementation: SignatureAggregatorImplementation::Consensus(aggregator),
+            synthetics,
             signed_entries_source,
             payload_sink,
         };
@@ -97,27 +110,39 @@ impl SignatureAggregator {
             }
         };
 
-        let (payload_age_sink, payload_age_source) = {
-            let now = SystemTime::now();
-            let later = now + Duration::from_secs(60);
-            watch::channel((now, later))
-        };
+        let payload_ages: DashMap<String, (SystemTime, SystemTime)> = self
+            .synthetics
+            .into_iter()
+            .map(|synthetic| {
+                let now = SystemTime::now();
+                let later = now + Duration::from_secs(60);
+                (synthetic, (now, later))
+            })
+            .collect();
+        let payload_ages = Arc::new(payload_ages);
 
+        let ages = payload_ages.clone();
         let monitor_task = async move {
             loop {
-                let (last_updated, valid_until) = *payload_age_source.borrow();
-                let is_valid: u64 = if SystemTime::now() < valid_until {
-                    1
-                } else {
-                    0
-                };
-                if let Ok(age) = SystemTime::now().duration_since(last_updated) {
-                    if let Ok(age_in_millis) = u64::try_from(age.as_millis()) {
-                        debug!(
-                            histogram.payload_age = age_in_millis,
-                            histogram.payload_is_valid = is_valid,
-                            "payload metrics"
-                        );
+                for entry in ages.iter() {
+                    let synthetic = entry.key().clone();
+                    let (last_updated, valid_until) = *entry.value();
+                    drop(entry);
+
+                    let is_valid: u64 = if SystemTime::now() < valid_until {
+                        1
+                    } else {
+                        0
+                    };
+                    if let Ok(age) = SystemTime::now().duration_since(last_updated) {
+                        if let Ok(age_in_millis) = u64::try_from(age.as_millis()) {
+                            debug!(
+                                histogram.price_feed_age = age_in_millis,
+                                histogram.price_feed_is_valid = is_valid,
+                                synthetic,
+                                "price feed metrics"
+                            );
+                        }
                     }
                 }
                 sleep(Duration::from_secs(1)).await;
@@ -129,8 +154,11 @@ impl SignatureAggregator {
             while let Some((publisher, payload)) = payload_source.recv().await {
                 // update the payload age monitor now that we have a new payload
                 let last_updated = payload.timestamp;
-                let valid_to = find_end_of_payload_validity(&payload);
-                payload_age_sink.send_replace((last_updated, valid_to));
+                for entry in &payload.entries {
+                    let synthetic = entry.data.data.synthetic.clone();
+                    let valid_until = find_end_of_entry_validity(entry);
+                    payload_ages.insert(synthetic, (last_updated, valid_until));
+                }
 
                 let entries = payload
                     .entries
@@ -166,28 +194,15 @@ impl SignatureAggregator {
     }
 }
 
-fn find_end_of_payload_validity(payload: &SignedEntries) -> SystemTime {
-    let mut valid_to = None;
-    for price_feed in &payload.entries {
-        let upper_bound = price_feed.data.data.validity.upper_bound;
-        match upper_bound.bound_type {
-            IntervalBoundType::NegativeInfinity => {
-                return SystemTime::UNIX_EPOCH;
-            }
-            IntervalBoundType::PositiveInfinity => {
-                continue;
-            }
-            IntervalBoundType::Finite(unix_timestamp) => {
-                let payload_valid_to =
-                    SystemTime::UNIX_EPOCH + Duration::from_millis(unix_timestamp);
-                if valid_to.is_some_and(|v| v < payload_valid_to) {
-                    continue;
-                }
-                valid_to.replace(payload_valid_to);
-            }
+fn find_end_of_entry_validity(entry: &SignedEntry) -> SystemTime {
+    let upper_bound = entry.data.data.validity.upper_bound;
+    match upper_bound.bound_type {
+        IntervalBoundType::NegativeInfinity => SystemTime::UNIX_EPOCH,
+        IntervalBoundType::PositiveInfinity => SystemTime::now() + Duration::from_secs(60 * 525600),
+        IntervalBoundType::Finite(unix_timestamp) => {
+            SystemTime::UNIX_EPOCH + Duration::from_millis(unix_timestamp)
         }
     }
-    valid_to.unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
 #[derive(Serialize, Clone)]

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -75,7 +75,6 @@ impl SignatureAggregator {
 
         let aggregator = ConsensusSignatureAggregator::new(
             config,
-            network.id.clone(),
             network.signer_channel(),
             price_source,
             leader_source,

--- a/src/signature_aggregator/consensus_aggregator.rs
+++ b/src/signature_aggregator/consensus_aggregator.rs
@@ -27,7 +27,6 @@ pub struct ConsensusSignatureAggregator {
 impl ConsensusSignatureAggregator {
     pub fn new(
         config: &OracleConfig,
-        id: NodeId,
         channel: NetworkChannel<SignerMessage>,
         price_source: watch::Receiver<Vec<PriceFeedEntry>>,
         leader_source: watch::Receiver<RaftLeader>,
@@ -36,7 +35,7 @@ impl ConsensusSignatureAggregator {
         let (key, public_key) = Self::load_keys(config)?;
         let (outgoing_message_sink, message_source) = channel.split();
         let signer = Signer::new(
-            id,
+            config.id.clone(),
             key,
             public_key,
             price_source,

--- a/src/signature_aggregator/consensus_aggregator.rs
+++ b/src/signature_aggregator/consensus_aggregator.rs
@@ -8,6 +8,7 @@ use tokio::{
     time::sleep,
 };
 use tracing::{info_span, warn};
+use uuid::Uuid;
 
 use crate::{
     config::OracleConfig,
@@ -62,8 +63,9 @@ impl ConsensusSignatureAggregator {
                 if !matches!(*leader.borrow(), RaftLeader::Myself) {
                     continue;
                 }
-                let span = info_span!("new_round");
-                if let Err(err) = sink.send(SignerEvent::RoundStarted).await {
+                let round = Uuid::new_v4().to_string();
+                let span = info_span!("new_round", round);
+                if let Err(err) = sink.send(SignerEvent::RoundStarted(round)).await {
                     span.in_scope(|| warn!("Failed to start new round: {}", err));
                     break;
                 }


### PR DESCRIPTION
Right now, when a node participates in signing a price payload, it can choose to either sign every price feed in the payload, or to not sign any of them. This means that if a node disagrees about the prices for even one synthetic, it can't participate in the current round.

This PR updates the signer protocol and internal logic, so that followers choose which price feeds they are willing to sign. The leader will keep requesting commitments from followers until
1. For each synthetic, a quorum of followers have committed to sign its price feed
2. Every follower has decided which price feeds they'll sign
3. We hit a 5-second timeout (so that the leader doesn't wait forever if a follower is hanging or something)

Once any of those conditions are hit, the leader will start gathering signatures. 

## This PR has breaking changes

Most signer requests/responses include btreemaps instead of vecs, so that we know which synthetics are getting signed.
Followers also send their entire price list to the leader, to help with future development.