### PR TITLE
[SB-1893] abdicate when we fail to sign too many payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,17 +44,13 @@ struct Node {
 
 impl Node {
     pub fn new(config: Arc<OracleConfig>) -> Result<Self> {
-        let heartbeat = config.heartbeat;
-        let timeout = config.timeout;
-
-        // quorum is set to a majority of expected nodes (which includes ourself!)
-        let quorum = ((config.network.peers.len() + 1) / 2) + 1;
-
         let (leader_tx, leader_rx) = watch::channel(RaftLeader::Unknown);
         let (health_server, health_sink) = HealthServer::new(&config.network, leader_rx.clone());
 
         // Construct a peer-to-peer network that can connect to peers, and dispatch messages to the correct state machine
         let mut network = Network::new(&config.network, health_sink.clone());
+
+        let (raft, _raft_client) = Raft::new(&config, &mut network, leader_tx);
 
         let (price_feed_tx, price_feed_rx) = watch::channel(vec![]);
         let (price_audit_tx, price_audit_rx) = watch::channel(vec![]);
@@ -70,8 +66,6 @@ impl Node {
         let api_server = APIServer::new(&config, payload_source.clone(), price_audit_rx);
 
         let publisher = Publisher::new(&network.id, payload_source)?;
-
-        let raft = Raft::new(quorum, heartbeat, timeout, &mut network, leader_tx);
 
         Ok(Node {
             api_server,

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1,34 +1,48 @@
+mod client;
 mod logic;
 #[cfg(test)]
 mod tests;
 
 use tokio::{
     select,
-    sync::watch,
+    sync::{mpsc, watch},
     time::{sleep_until, Instant},
 };
 use tracing::{debug, info, info_span};
 
-use crate::network::{Network, NetworkChannel, NodeId};
+use crate::{
+    config::OracleConfig,
+    network::{Network, NetworkChannel, NodeId},
+};
 
+pub use client::RaftClient;
 use logic::RaftState;
 pub use logic::{RaftLeader, RaftMessage};
 
+pub enum RaftCommand {
+    /// If we are currently leader, step down.
+    /// Stop sending heartbeats, so that another node triggers election and wins.
+    Abdicate,
+}
+
 pub struct Raft {
     pub id: NodeId,
-
+    command_source: mpsc::Receiver<RaftCommand>,
     channel: NetworkChannel<RaftMessage>,
     state: RaftState,
 }
 
 impl Raft {
     pub fn new(
-        quorum: usize,
-        heartbeat_freq: std::time::Duration,
-        timeout_freq: std::time::Duration,
+        config: &OracleConfig,
         network: &mut Network,
         leader_sink: watch::Sender<RaftLeader>,
-    ) -> Self {
+    ) -> (Self, RaftClient) {
+        // quorum is set to a majority of expected nodes (which includes ourself!)
+        let quorum = ((config.network.peers.len() + 1) / 2) + 1;
+        let heartbeat_freq = config.heartbeat;
+        let timeout_freq = config.timeout;
+
         info!(
             quorum = quorum,
             heartbeat = format!("{:?}", heartbeat_freq),
@@ -45,11 +59,22 @@ impl Raft {
             timeout_freq,
             leader_sink,
         );
-        Raft { id, channel, state }
+        let (command_sink, command_source) = mpsc::channel(10);
+        let client = RaftClient::new(command_sink);
+        (
+            Self {
+                id,
+                command_source,
+                channel,
+                state,
+            },
+            client,
+        )
     }
 
     pub async fn handle_messages(self) {
         let (sender, mut receiver) = self.channel.split();
+        let mut command_source = self.command_source;
         let mut state = self.state;
         loop {
             let next_event = state.next_event(Instant::now());
@@ -61,6 +86,14 @@ impl Raft {
                         state.receive(Instant::now(), msg)
                     })
                 },
+                Some(command) = command_source.recv() => {
+                    let span = info_span!("raft_command");
+                    span.in_scope(|| {
+                        match command {
+                            RaftCommand::Abdicate => state.abdicate()
+                        }
+                    })
+                }
                 _ = sleep_until(next_event) => {
                     let span = info_span!("raft_tick");
                     span.in_scope(|| {

--- a/src/raft/client.rs
+++ b/src/raft/client.rs
@@ -1,0 +1,19 @@
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use super::RaftCommand;
+
+#[derive(Clone)]
+pub struct RaftClient(mpsc::Sender<RaftCommand>);
+
+impl RaftClient {
+    pub fn new(sender: mpsc::Sender<RaftCommand>) -> Self {
+        Self(sender)
+    }
+
+    pub fn abdicate(&self) {
+        if let Err(error) = self.0.try_send(RaftCommand::Abdicate) {
+            warn!("Could not abdicate raft leadership: {}", error);
+        };
+    }
+}


### PR DESCRIPTION
If every node except one agrees on a synthetic's price, but the one dissenting node is the leader, no other nodes will sign that synthetic's payload and the system will stop updating its value.

To avoid this, have the leader trigger a raft failover ("abdicate") whenever it fails to publish values for some synthetic for 5 rounds in a row. The failover is passive; the leader will still consider itself to be leader, but it will
- stop sending heartbeats to its followers (so eventually, one of them will trigger an election)
- not participate in the next election