### PR TITLE
Make the leader track variance between prices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1724,8 @@ dependencies = [
  "minicbor-io",
  "num-bigint",
  "num-integer",
+ "num-rational",
+ "num-traits",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ minicbor = { version = "0.20", features = ["derive", "std"] }
 minicbor-io = { version = "0.15", features = ["async-io"] }
 num-bigint = "0.4"
 num-integer = "0.1"
+num-rational = "0.4"
+num-traits = "0.2"
 opentelemetry = "0.24"
 opentelemetry-otlp = { version = "0.17", features = ["gzip-tonic", "tls-webpki-roots"] }
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -1,5 +1,6 @@
 pub mod consensus_aggregator;
 pub mod price_comparator;
+pub mod price_instrumentation;
 pub mod signer;
 pub mod single_aggregator;
 

--- a/src/signature_aggregator/price_instrumentation.rs
+++ b/src/signature_aggregator/price_instrumentation.rs
@@ -1,0 +1,105 @@
+use std::collections::BTreeMap;
+
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+use tracing::debug;
+
+type Ratio = num_rational::Ratio<BigInt>;
+use crate::price_feed::{PriceFeed, PriceFeedEntry};
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct PriceKey {
+    synthetic: String,
+    collateral: usize,
+}
+
+fn variance(values: &[Ratio]) -> Ratio {
+    let average = values.iter().sum::<Ratio>() / Ratio::from_integer(BigInt::from(values.len()));
+    values.iter().map(|v| (v - &average).pow(2)).sum::<Ratio>()
+        / Ratio::from_integer(BigInt::from(values.len()))
+}
+
+#[derive(Default)]
+pub struct PriceInstrumentation {
+    round: Option<String>,
+    collateral_names: BTreeMap<String, Vec<String>>,
+    all_prices: BTreeMap<PriceKey, Vec<Ratio>>,
+}
+
+impl PriceInstrumentation {
+    pub fn begin_round(&mut self, round: &str, my_prices: &[PriceFeedEntry]) {
+        self.end_round();
+        self.round = Some(round.to_string());
+        self.collateral_names = extract_collateral_names(my_prices);
+
+        for (key, value) in my_prices
+            .iter()
+            .flat_map(|e| extract_prices_from_feed(&e.data))
+        {
+            self.all_prices.insert(key, vec![value]);
+        }
+    }
+
+    pub fn track_prices(&mut self, round: &str, prices: &[PriceFeed]) {
+        if !self.round.as_ref().is_some_and(|r| r == round) {
+            return;
+        }
+        for (key, value) in prices.iter().flat_map(extract_prices_from_feed) {
+            self.all_prices
+                .entry(key)
+                .and_modify(|values| values.push(value));
+        }
+    }
+
+    pub fn end_round(&mut self) {
+        if self.round.take().is_some() {
+            self.emit_price_variance();
+        }
+        self.round = None;
+        self.all_prices.clear();
+    }
+
+    fn emit_price_variance(&self) {
+        for (key, values) in self.all_prices.iter() {
+            let synthetic_name = &key.synthetic;
+            let collateral_name = &self.collateral_names[synthetic_name][key.collateral];
+            let variance = variance(values).to_f64().expect("infallible");
+            debug!(
+                collateral_name,
+                synthetic_name,
+                histogram.collateral_price_variance = variance,
+                "price variance"
+            );
+        }
+    }
+}
+
+fn extract_prices_from_feed(feed: &PriceFeed) -> impl Iterator<Item = (PriceKey, Ratio)> + '_ {
+    feed.collateral_prices
+        .iter()
+        .enumerate()
+        .map(|(index, coll)| {
+            let key = PriceKey {
+                synthetic: feed.synthetic.clone(),
+                collateral: index,
+            };
+            let value = Ratio::new(coll.clone().into(), feed.denominator.clone().into());
+            (key, value)
+        })
+}
+
+fn extract_collateral_names(entries: &[PriceFeedEntry]) -> BTreeMap<String, Vec<String>> {
+    entries
+        .iter()
+        .map(|e| {
+            let synthetic = e.data.synthetic.clone();
+            let collateral = e
+                .data
+                .collateral_names
+                .as_ref()
+                .cloned()
+                .expect("collateral names should always be included");
+            (synthetic, collateral)
+        })
+        .collect()
+}


### PR DESCRIPTION
Before the leader starts a new round, make them emit a price variance metric. Followers are already sending all of the prices they chose to the leader, so we already have all the info we need to calculate this