### PR TITLE
Add timeouts to network operations

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -1,8 +1,9 @@
-api_port: 8080      # Port to serve API requests
-network_port: 31415 # Port to handle traffic from other nodes
-health_port: 18000  # Port to report our health status
-heartbeat_ms: 500   # How long should the leader wait before sending a heartbeat
-timeout_ms: 2000     # How long should we wait before picking a new leader
+api_port: 8080            # Port to serve API requests
+network_port: 31415       # Port to handle traffic from other nodes
+health_port: 18000        # Port to report our health status
+heartbeat_ms: 500         # How long should the leader wait before sending a heartbeat
+timeout_ms: 2000          # How long should we wait before picking a new leader
+network_timeout_ms: 30000 # How long to allow TCP requests to run before timing out
 consensus: true
 logs:
   json: true

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ struct RawOracleConfig {
     pub network_port: u16,
     pub health_port: u16,
     pub api_port: u16,
+    pub network_timeout_ms: u64,
     pub consensus: bool,
     pub peers: Vec<RawPeerConfig>,
     pub heartbeat_ms: u64,
@@ -119,6 +120,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             id: id.clone(),
             private_key,
             peers,
+            timeout: Duration::from_millis(raw.network_timeout_ms),
         };
 
         let logs = LogConfig {
@@ -157,6 +159,7 @@ pub struct NetworkConfig {
     pub private_key: SigningKey,
     pub port: u16,
     pub peers: Vec<Peer>,
+    pub timeout: Duration,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Make sure that every read/write in the networking layer has a timeout on it. Currently, we use a ping heartbeat to detect if existing connections are alive or not, but when we're _opening_ a connection there's nothing preventing us from hanging forever waiting for a response.

The timeout is very high (30 seconds), so we should only hit it if something is going wrong. We use the same timeout on reads, but since we send/receive pings every 5 seconds, we will never hit that timeout under normal operation.

Also, recover from errors when receiving an incoming connection, or hanging forever when opening an outgoing one.