### PR TITLE
Fix bug where one node in bad state can lock other nodes into bad state

### DIFF
--- a/src/raft/logic.rs
+++ b/src/raft/logic.rs
@@ -189,8 +189,8 @@ impl RaftState {
                         info!(term = term, leader = %from, "New leader");
                     }
                     self.warned_about_quorum = false;
+                    self.last_event = timestamp;
                 }
-                self.last_event = timestamp;
                 vec![]
             }
             RaftMessage::RequestVote {


### PR DESCRIPTION
A subtle bug in the Raft implementation let nodes get stuck in a state where they didn't recognize a leader, but also wouldn't trigger their own elections.

Imagine there are three nodes, A B and C.
A thinks it's leader for term 1. It sends out term 1 heartbeats every second.
B was leader for term 2, but disconnected.
C thought B was leader for term 2, and when B disconnected it thought there was no leader.

In this scenario, C _should_ run for leader, but A's heartbeat from an older term was preventing it from running.