### PR TITLE
Refactor synthetics

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -102,14 +102,14 @@ currencies:
     price: 0.5923
     digits: 6
   - name: EUR
-    price: 1.06
+    price: 1.0931
     digits: 6
   - name: iUSD
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69555344
     price: 0.79
     digits: 6
   - name: JPY
-    price: 0.0067484985
+    price: 0.006900120752113162
     digits: 6
   - name: LENFI
     asset_id: 8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587.41414441

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -12,8 +12,8 @@ keygen:
   enabled: false
 synthetics:
   - name: USDb
-    price: 1
-    digits: 6
+    backing_currency: USD
+    invert: false
     collateral:
       - ADA
       - BTN
@@ -22,8 +22,8 @@ synthetics:
       - MIN
       - SNEK
   - name: USDs
-    price: 1
-    digits: 6
+    backing_currency: USD
+    invert: false
     collateral:
       - ADA
       - BTN
@@ -32,24 +32,24 @@ synthetics:
       - iUSD
       - myUSD
   - name: EURb
-    price: 1.0931
-    digits: 6
+    backing_currency: EUR
+    invert: false
     collateral:
       - ADA
       - USDb
       - USDs
       - BTN
   - name: JPYb
-    price: 0.006900120752113162
-    digits: 6
+    backing_currency: JPY
+    invert: false
     collateral:
       - ADA
       - USDb
       - USDs
       - BTN
   - name: BTCb
-    price: 45944.3
-    digits: 8
+    backing_currency: BTC
+    invert: false
     collateral:
       - ADA
       - USDb
@@ -60,8 +60,8 @@ synthetics:
       - MIN
       - SNEK
   - name: MATICb
-    price: 0.8206
-    digits: 6
+    backing_currency: MATIC
+    invert: false
     collateral:
       - ADA
       - BTCb
@@ -71,8 +71,8 @@ synthetics:
       - MIN
       - SNEK
   - name: SOLp
-    price: 0.010185788787483703
-    digits: 9
+    backing_currency: SOL
+    invert: true
     collateral:
       - ADA
       - USDb
@@ -82,12 +82,12 @@ synthetics:
       - LENFI
       - MIN
       - SNEK
-collateral:
+currencies:
   - name: ADA
-    price: 0.5235
+    price: 0.33
     digits: 6
-  - name: BTCb
-    price: 45944.3
+  - name: BTC
+    price: 58262
     digits: 8
   - name: BTN
     asset_id: 016be5325fd988fea98ad422fcfd53e5352cacfced5c106a932a35a4.42544e
@@ -101,13 +101,22 @@ collateral:
     asset_id: 9abf0afd2f236a19f2842d502d0450cbcd9c79f123a9708f96fd9b96.454e4353
     price: 0.5923
     digits: 6
+  - name: EUR
+    price: 1.06
+    digits: 6
   - name: iUSD
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69555344
     price: 0.79
     digits: 6
+  - name: JPY
+    price: 0.0067484985
+    digits: 6
   - name: LENFI
     asset_id: 8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587.41414441
     price: 3.79
+    digits: 6
+  - name: MATIC
+    price: 0.40
     digits: 6
   - name: MIN
     asset_id: 29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6.4d494e
@@ -119,12 +128,12 @@ collateral:
     digits: 6
   - name: SNEK
     asset_id: 279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b
-    price: 0.001194
+    price: 0.0007288
     digits: 0
-  - name: USDb
-    price: 1
-    digits: 6
-  - name: USDs
+  - name: SOL
+    price: 137.93
+    digits: 9
+  - name: USD
     price: 1
     digits: 6
 bybit:

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -178,6 +178,26 @@ coinbase:
     - token: SOL
       unit: USD
       product_id: SOL-USD
+maestro:
+  tokens:
+    - token: DJED
+      unit: ADA
+      dex: minswap
+    - token: ENCS
+      unit: ADA
+      dex: minswap
+    - token: iUSD
+      unit: ADA
+      dex: minswap
+    - token: LENFI
+      unit: ADA
+      dex: minswap
+    - token: MIN
+      unit: ADA
+      dex: minswap
+    - token: SNEK
+      unit: ADA
+      dex: minswap
 sundaeswap:
   use_api: false
   kupo_address: http://kupo:1442

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -136,20 +136,48 @@ currencies:
   - name: USD
     price: 1
     digits: 6
+binance:
+  tokens:
+    - token: ADA
+      unit: USD
+      stream: adausdt@ticker
+    - token: BTC
+      unit: USD
+      stream: btcusdt@ticker
+    - token: MATIC
+      unit: USD
+      stream: maticusdt@ticker
+    - token: SOL
+      unit: USD
+      stream: solusdt@ticker
 bybit:
   tokens:
     - token: ADA
       unit: USD
       stream: ADAUSDT
-    - token: BTCb
+    - token: BTC
       unit: USD
       stream: BTCUSDT
-    - token: MATICb
+    - token: MATIC
       unit: USD
       stream: MATICUSDT
-    - token: SOLp
+    - token: SOL
       unit: USD
       stream: SOLUSDT
+coinbase:
+  tokens:
+    - token: ADA
+      unit: USD
+      product_id: ADA-USD
+    - token: BTC
+      unit: USD
+      product_id: BTC-USD
+    - token: MATIC
+      unit: USD
+      product_id: MATIC-USD
+    - token: SOL
+      unit: USD
+      product_id: SOL-USD
 sundaeswap:
   use_api: false
   kupo_address: http://kupo:1442

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ struct RawOracleConfig {
     pub binance: BinanceConfig,
     pub bybit: ByBitConfig,
     pub coinbase: CoinbaseConfig,
+    pub maestro: MaestroConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub spectrum: SpectrumConfig,
@@ -54,6 +55,7 @@ pub struct OracleConfig {
     pub bybit: ByBitConfig,
     pub binance: BinanceConfig,
     pub coinbase: CoinbaseConfig,
+    pub maestro: MaestroConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub spectrum: SpectrumConfig,
@@ -149,6 +151,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             binance: raw.binance,
             bybit: raw.bybit,
             coinbase: raw.coinbase,
+            maestro: raw.maestro,
             sundaeswap: raw.sundaeswap,
             minswap: raw.minswap,
             spectrum: raw.spectrum,
@@ -270,6 +273,18 @@ pub struct CoinbaseTokenConfig {
     pub token: String,
     pub unit: String,
     pub product_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaestroConfig {
+    pub tokens: Vec<MaestroTokenConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct MaestroTokenConfig {
+    pub token: String,
+    pub unit: String,
+    pub dex: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,9 @@ struct RawOracleConfig {
     pub keygen: KeygenConfig,
     pub synthetics: Vec<SyntheticConfig>,
     pub currencies: Vec<CurrencyConfig>,
+    pub binance: BinanceConfig,
     pub bybit: ByBitConfig,
+    pub coinbase: CoinbaseConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub spectrum: SpectrumConfig,
@@ -50,6 +52,8 @@ pub struct OracleConfig {
     pub synthetics: Vec<SyntheticConfig>,
     pub currencies: Vec<CurrencyConfig>,
     pub bybit: ByBitConfig,
+    pub binance: BinanceConfig,
+    pub coinbase: CoinbaseConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub spectrum: SpectrumConfig,
@@ -142,7 +146,9 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             keygen: raw.keygen,
             synthetics: raw.synthetics,
             currencies: raw.currencies,
+            binance: raw.binance,
             bybit: raw.bybit,
+            coinbase: raw.coinbase,
             sundaeswap: raw.sundaeswap,
             minswap: raw.minswap,
             spectrum: raw.spectrum,
@@ -231,6 +237,18 @@ pub struct CurrencyConfig {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct BinanceConfig {
+    pub tokens: Vec<BinanceTokenConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct BinanceTokenConfig {
+    pub token: String,
+    pub unit: String,
+    pub stream: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ByBitConfig {
     pub tokens: Vec<ByBitTokenConfig>,
 }
@@ -240,6 +258,18 @@ pub struct ByBitTokenConfig {
     pub token: String,
     pub unit: String,
     pub stream: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CoinbaseConfig {
+    pub tokens: Vec<CoinbaseTokenConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CoinbaseTokenConfig {
+    pub token: String,
+    pub unit: String,
+    pub product_id: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ struct RawOracleConfig {
     pub frost_address: Option<String>,
     pub keygen: KeygenConfig,
     pub synthetics: Vec<SyntheticConfig>,
-    pub collateral: Vec<CollateralConfig>,
+    pub currencies: Vec<CurrencyConfig>,
     pub bybit: ByBitConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
@@ -48,7 +48,7 @@ pub struct OracleConfig {
     pub frost_address: Option<String>,
     pub keygen: KeygenConfig,
     pub synthetics: Vec<SyntheticConfig>,
-    pub collateral: Vec<CollateralConfig>,
+    pub currencies: Vec<CurrencyConfig>,
     pub bybit: ByBitConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
@@ -76,15 +76,11 @@ impl OracleConfig {
             .collect()
     }
 
-    fn build_asset_lookup(&self) -> HashMap<&String, &CollateralConfig> {
-        let mut result = HashMap::new();
-        for collateral in &self.collateral {
-            result.insert(&collateral.name, collateral);
-        }
-        result
+    fn build_asset_lookup(&self) -> HashMap<&String, &CurrencyConfig> {
+        self.currencies.iter().map(|c| (&c.name, c)).collect()
     }
 
-    fn find_asset_id(asset: &CollateralConfig) -> Option<AssetId> {
+    fn find_asset_id(asset: &CurrencyConfig) -> Option<AssetId> {
         if asset.name == "ADA" {
             return None;
         }
@@ -145,7 +141,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             frost_address: raw.frost_address,
             keygen: raw.keygen,
             synthetics: raw.synthetics,
-            collateral: raw.collateral,
+            currencies: raw.currencies,
             bybit: raw.bybit,
             sundaeswap: raw.sundaeswap,
             minswap: raw.minswap,
@@ -221,13 +217,13 @@ impl TryFrom<RawPeerConfig> for Peer {
 #[derive(Debug, Deserialize)]
 pub struct SyntheticConfig {
     pub name: String,
-    pub price: Decimal,
-    pub digits: u32,
+    pub backing_currency: String,
+    pub invert: bool,
     pub collateral: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct CollateralConfig {
+pub struct CurrencyConfig {
     pub name: String,
     pub asset_id: Option<String>,
     pub price: Decimal,

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -49,7 +49,7 @@ impl PriceAggregator {
             SourceAdapter::new(MinswapSource::new(&config)?),
             SourceAdapter::new(SpectrumSource::new(&config)?),
         ];
-        if let Some(maestro_source) = MaestroSource::new()? {
+        if let Some(maestro_source) = MaestroSource::new(&config)? {
             sources.push(SourceAdapter::new(maestro_source));
         } else {
             warn!("Not querying maestro, because no MAESTRO_API_KEY was provided");

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -43,9 +43,9 @@ impl PriceAggregator {
         config: Arc<OracleConfig>,
     ) -> Result<Self> {
         let mut sources = vec![
-            SourceAdapter::new(BinanceSource::new()),
+            SourceAdapter::new(BinanceSource::new(&config)),
             SourceAdapter::new(ByBitSource::new(&config)),
-            SourceAdapter::new(CoinbaseSource::new()),
+            SourceAdapter::new(CoinbaseSource::new(&config)),
             SourceAdapter::new(MinswapSource::new(&config)?),
             SourceAdapter::new(SpectrumSource::new(&config)?),
         ];

--- a/src/sources/bybit.rs
+++ b/src/sources/bybit.rs
@@ -135,9 +135,6 @@ impl ByBitSource {
                                         data.symbol
                                     );
                                     None
-                                } else if info.token == "SOLp" {
-                                    // We track inverse solana prices
-                                    Some(Decimal::ONE / p)
                                 } else {
                                     Some(p)
                                 }


### PR DESCRIPTION
Update how the oracle tracks and reports on the prices of synthetics, in preparation for tracking real values for EUR and JPY.

Before this PR, we treated synthetics as their own independent currency; our price sources would report the value of "BTCb" rather than "BTC" and "SOLp" rather than "SOL". With this PR, we no longer track prices of synthetics directly; we track the prices of their backing currencies, and the system uses "price of BTC" as"price of BTCb", and "inverted price of SOL" as "price of SOLp".

Benefits:
 - API sources are all dumber; they just need to report the value of one currency in terms of another, they don't all need to know how to turn SOL prices into SOLp.
 - API sources are all config-driven, so we can make them report on different currencies without code changes
 - We can support more weird synthetics like extra-stable ("USDs") or inverted ("SOLp") by just updating config, without changing any code.