### PR TITLE
Add FXRatesAPI source for fiat currencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +476,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "counter"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +664,17 @@ name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1305,6 +1351,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,8 +1773,10 @@ dependencies = [
  "axum",
  "bech32 0.11.0",
  "chacha20poly1305",
+ "chrono",
  "clap",
  "config",
+ "cron",
  "cynic",
  "dashmap",
  "ed25519",
@@ -3320,6 +3391,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ chacha20poly1305 = "0.10"
 cynic = "3.4"
 clap = { version = "4.5.1", features = ["derive"] }
 config = "0.14"
+chrono = "0.4"
+cron = "0.12"
 dashmap = "6"
 ed25519 = { version = "2.2", features = ["pkcs8", "pem"] }
 ed25519-dalek = { version = "2.1" }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ MAESTRO_API_KEY=[key goes here]
 ```
 If you don't pass an API key, the oracle will still run, but it won't include maestro pricing data.
 
+### Set up FXRatesAPI
+
+FXRatesAPI needs an API key as well. To get a key for this API, visit https://fxratesapi.com/auth/signup and create an account. The free tier is fine.
+
+The oracle reads the key from the environment variable `FXRATESAPI_API_KEY`. You can add it to your `.env` file:
+```sh
+FXRATESAPI_API_KEY=[key goes here]
+```
+The oracle will run without an FXRatesAPI key, but this API is currently the only source of truth for some fiat currencies, so it is highly recommended to create one.
+
 ## Running
 
 ```sh

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -102,14 +102,14 @@ currencies:
     price: 0.5923
     digits: 6
   - name: EUR
-    price: 1.0931
+    price: 1.102912639903575
     digits: 6
   - name: iUSD
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69555344
     price: 0.79
     digits: 6
   - name: JPY
-    price: 0.006900120752113162
+    price: 0.0067741365658039
     digits: 6
   - name: LENFI
     asset_id: 8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587.41414441

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -273,6 +273,7 @@ spectrum:
   max_concurrency: 3
   retries: 3
 fxratesapi:
+  cron: "0 4 * ? * ? *" # Run four minutes past the hour, every hour
   currencies:
     - EUR
     - JPY

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -272,3 +272,8 @@ spectrum:
       asset_id: f8fd67ee46f66da669f68dc941090eb753687636b47fc6fd7f5e6254.534e454b5f4144415f4e4654
   max_concurrency: 3
   retries: 3
+fxratesapi:
+  currencies:
+    - EUR
+    - JPY
+  base: USD

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ struct RawOracleConfig {
     pub binance: BinanceConfig,
     pub bybit: ByBitConfig,
     pub coinbase: CoinbaseConfig,
+    pub fxratesapi: FxRatesApiConfig,
     pub maestro: MaestroConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
@@ -55,6 +56,7 @@ pub struct OracleConfig {
     pub bybit: ByBitConfig,
     pub binance: BinanceConfig,
     pub coinbase: CoinbaseConfig,
+    pub fxratesapi: FxRatesApiConfig,
     pub maestro: MaestroConfig,
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
@@ -151,6 +153,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             binance: raw.binance,
             bybit: raw.bybit,
             coinbase: raw.coinbase,
+            fxratesapi: raw.fxratesapi,
             maestro: raw.maestro,
             sundaeswap: raw.sundaeswap,
             minswap: raw.minswap,
@@ -273,6 +276,12 @@ pub struct CoinbaseTokenConfig {
     pub token: String,
     pub unit: String,
     pub product_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FxRatesApiConfig {
+    pub currencies: Vec<String>,
+    pub base: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,6 +280,7 @@ pub struct CoinbaseTokenConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct FxRatesApiConfig {
+    pub cron: String,
     pub currencies: Vec<String>,
     pub base: String,
 }

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -17,8 +17,8 @@ use crate::{
     price_feed::{IntervalBound, PriceFeed, PriceFeedEntry, Validity},
     sources::{
         binance::BinanceSource, bybit::ByBitSource, coinbase::CoinbaseSource,
-        maestro::MaestroSource, minswap::MinswapSource, source::PriceInfo,
-        spectrum::SpectrumSource, sundaeswap::SundaeSwapSource,
+        fxratesapi::FxRatesApiSource, maestro::MaestroSource, minswap::MinswapSource,
+        source::PriceInfo, spectrum::SpectrumSource, sundaeswap::SundaeSwapSource,
         sundaeswap_kupo::SundaeSwapKupoSource,
     },
 };
@@ -53,6 +53,11 @@ impl PriceAggregator {
             sources.push(SourceAdapter::new(maestro_source));
         } else {
             warn!("Not querying maestro, because no MAESTRO_API_KEY was provided");
+        }
+        if let Some(fxratesapi_source) = FxRatesApiSource::new(&config)? {
+            sources.push(SourceAdapter::new(fxratesapi_source));
+        } else {
+            warn!("Not querying FXRatesAPI, because no FXRATESAPI_API_KEY was provided");
         }
         if config.sundaeswap.use_api {
             sources.push(SourceAdapter::new(SundaeSwapSource::new(&config)?));

--- a/src/sources/fxratesapi.rs
+++ b/src/sources/fxratesapi.rs
@@ -1,0 +1,122 @@
+use std::{collections::BTreeMap, env, time::Duration};
+
+use anyhow::{anyhow, Result};
+use futures::{future::BoxFuture, FutureExt};
+use num_traits::Inv;
+use reqwest::Client;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+use tokio::time::sleep;
+use tracing::warn;
+
+use crate::{
+    config::OracleConfig,
+    sources::source::{PriceInfo, PriceSink, Source},
+};
+
+const URL: &str = "https://api.fxratesapi.com/latest";
+
+pub struct FxRatesApiSource {
+    api_key: String,
+    client: Client,
+    currencies: Vec<String>,
+    base: String,
+}
+
+impl Source for FxRatesApiSource {
+    fn name(&self) -> String {
+        "FXRatesAPI".into()
+    }
+    fn max_time_without_updates(&self) -> Duration {
+        // one hour
+        Duration::from_secs(60 * 60)
+    }
+    fn tokens(&self) -> Vec<String> {
+        self.currencies.clone()
+    }
+    fn query<'a>(&'a self, sink: &'a PriceSink) -> BoxFuture<Result<()>> {
+        self.query_impl(sink).boxed()
+    }
+}
+
+impl FxRatesApiSource {
+    pub fn new(config: &OracleConfig) -> Result<Option<Self>> {
+        let Ok(api_key) = env::var("FXRATESAPI_API_KEY") else {
+            return Ok(None);
+        };
+        let client = Client::builder().build()?;
+        let currencies = config.fxratesapi.currencies.clone();
+        let base = config.fxratesapi.base.clone();
+        Ok(Some(Self {
+            api_key,
+            client,
+            currencies,
+            base,
+        }))
+    }
+
+    async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        let response = self
+            .client
+            .get(URL)
+            .query(&[
+                ("amount", "1"),
+                ("api_key", &self.api_key),
+                ("base", &self.base),
+                ("currencies", &self.currencies.join(",")),
+            ])
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await?;
+        let contents = response.text().await?;
+        let payload = match serde_json::from_str(&contents)? {
+            FxRatesApiResponse::Success(success) => success,
+            FxRatesApiResponse::Error(error) => {
+                return Err(anyhow!(
+                    "FXRatesAPI error {}: {}",
+                    error.error,
+                    error.description
+                ));
+            }
+        };
+
+        for currency in &self.currencies {
+            let Some(&value) = payload.rates.get(currency) else {
+                warn!("No value found for {currency}");
+                continue;
+            };
+            if value == 0.0 {
+                warn!("FXRatesAPI reported value of {currency} as zero, ignoring");
+                continue;
+            }
+            sink.send(PriceInfo {
+                token: currency.clone(),
+                unit: self.base.clone(),
+                value: value.inv().try_into()?,
+                reliability: Decimal::ONE,
+            })?;
+        }
+
+        sleep(Duration::from_secs(60 * 60)).await;
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum FxRatesApiResponse {
+    Success(FxRatesApiSuccessResponse),
+    Error(FxRatesApiErrorResponse),
+}
+
+#[derive(Deserialize)]
+struct FxRatesApiSuccessResponse {
+    rates: BTreeMap<String, f64>,
+}
+
+#[derive(Deserialize)]
+struct FxRatesApiErrorResponse {
+    error: String,
+    description: String,
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,6 +1,7 @@
 pub mod binance;
 pub mod bybit;
 pub mod coinbase;
+pub mod fxratesapi;
 pub mod kupo;
 pub mod maestro;
 pub mod minswap;

--- a/src/sources/source.rs
+++ b/src/sources/source.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use futures::future::BoxFuture;
 use rust_decimal::Decimal;
@@ -15,6 +17,9 @@ pub type PriceSink = mpsc::UnboundedSender<PriceInfo>;
 
 pub trait Source {
     fn name(&self) -> String;
+    fn max_time_without_updates(&self) -> Duration {
+        Duration::from_secs(30)
+    }
     fn tokens(&self) -> Vec<String>;
     fn query<'a>(&'a self, sink: &'a PriceSink) -> BoxFuture<Result<()>>;
 }


### PR DESCRIPTION
Support querying [FXRatesAPI](https://fxratesapi.com/) to find prices for EUR and JPY.

Nodes will use the free tier of this API (at least while we're using the test cluster), which only updates prices once per hour and only allows 1000 requests/month (~30 per day). To avoid rate limiting, we're only calling the API once per hour. We use a cron schedule so that every node is making their hourly request at about the same time; that will help keep the cluster in sync.

The node needs an `FXRATESAPI_API_KEY` env var to query that API. It will run without one, but its EUR/JPY prices will probably drift and it won't be able to reach quorum.

**This is a breaking change**. We're now actually tracking prices for EUR and JPY, and those prices have significantly drifted from our original hard-coded values; nodes will disagree on the value of EURb and JPYb until everyone is updated and using this.