### PR TITLE
Improve kupo logging and error handling

### DIFF
--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -9,7 +9,7 @@ use num_bigint::BigUint;
 use num_integer::Integer;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use tokio::{sync::watch::Sender, task::JoinSet, time::sleep};
-use tracing::{debug, warn, Instrument};
+use tracing::{debug, error, warn};
 
 use crate::{
     config::{OracleConfig, SyntheticConfig},
@@ -79,28 +79,20 @@ impl PriceAggregator {
         // Make each source update its price map asynchronously.
         for source in sources {
             let health = health.clone();
-            set.spawn(
-                async move {
-                    source.run(health).await;
-                }
-                .in_current_span(),
-            );
+            set.spawn(source.run(health));
         }
 
         // Every second, we report the latest values from those price maps.
-        set.spawn(
-            async move {
-                loop {
-                    self.report(&price_maps);
-                    sleep(Duration::from_secs(1)).await;
-                }
+        set.spawn(async move {
+            loop {
+                self.report(&price_maps);
+                sleep(Duration::from_secs(1)).await;
             }
-            .in_current_span(),
-        );
+        });
 
         while let Some(res) = set.join_next().await {
             if let Err(error) = res {
-                warn!("{:?}", error);
+                error!("Panicked while querying data from an API! {:?}", error);
             }
         }
     }

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -133,6 +133,16 @@ impl Display for SignerEvent {
         }
     }
 }
+impl SignerEvent {
+    fn name(&self) -> &str {
+        match self {
+            Self::RoundStarted(_) => "RoundStarted",
+            Self::RoundGracePeriodEnded(_) => "RoundGracePeriodEnded",
+            Self::Message(_, _, _) => "Message",
+            Self::LeaderChanged(_) => "LeaderChanged",
+        }
+    }
+}
 
 enum LeaderState {
     Ready,
@@ -282,10 +292,10 @@ impl Signer {
 
     #[instrument(name = "process_signer", skip_all, fields(round = self.state.round(), state = %self.state))]
     pub async fn process(&mut self, event: SignerEvent) {
-        info!("Started event: {}", event);
+        info!(%event, "Started {} event", event.name());
         match self.do_process(event.clone()).await {
             Ok(()) => {
-                info!("Finished event: {}", event)
+                info!(%event, "Finished event: {}", event.name())
             }
             Err(error) => {
                 warn!(%error, "Error occurred during signing flow");

--- a/src/sources/bybit.rs
+++ b/src/sources/bybit.rs
@@ -10,7 +10,7 @@ use tokio::{
     time::{sleep, Duration},
 };
 use tokio_websockets::{ClientBuilder, Message};
-use tracing::{warn, Instrument};
+use tracing::warn;
 
 use crate::config::OracleConfig;
 
@@ -103,8 +103,7 @@ impl ByBitSource {
                     return Err(anyhow!("Error sending heartbeat: {}", err));
                 }
             }
-        }
-        .in_current_span();
+        };
 
         let consumer = async move {
             while let Some(result) = stream.next().await {
@@ -167,9 +166,8 @@ impl ByBitSource {
                     }
                 };
             }
-            Ok(())
-        }
-        .in_current_span();
+            Err(anyhow!("ByBit stream has closed"))
+        };
 
         select! {
             res = heartbeat => res,

--- a/src/sources/kupo.rs
+++ b/src/sources/kupo.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use futures::{stream::FuturesUnordered, Future, StreamExt};
-use kupon::{Client, HealthStatus};
+use kupon::{AssetId, Client, HealthStatus, Match};
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
@@ -45,6 +45,21 @@ pub async fn wait_for_sync(client: &Client) {
                 sleep(Duration::from_secs(10)).await;
             }
         }
+    }
+}
+
+pub fn get_asset_value(matc: &Match, asset_id: &Option<AssetId>) -> Option<u64> {
+    get_asset_value_minus_tx_fee(matc, asset_id, 0)
+}
+
+pub fn get_asset_value_minus_tx_fee(
+    matc: &Match,
+    asset_id: &Option<AssetId>,
+    tx_fee: u64,
+) -> Option<u64> {
+    match asset_id {
+        Some(token) => matc.value.assets.get(token).copied(),
+        None => matc.value.coins.checked_sub(tx_fee),
     }
 }
 

--- a/src/sources/minswap.rs
+++ b/src/sources/minswap.rs
@@ -10,7 +10,7 @@ use tracing::{warn, Level};
 use crate::config::{HydratedPool, OracleConfig};
 
 use super::{
-    kupo::{wait_for_sync, MaxConcurrencyFutureSet},
+    kupo::{get_asset_value, wait_for_sync, MaxConcurrencyFutureSet},
     source::{PriceInfo, PriceSink, Source},
 };
 
@@ -83,13 +83,14 @@ impl MinswapSource {
                     return Err(anyhow!("more than one pool found for {}", pool.pool.token));
                 }
                 let matc = result.remove(0);
-                let token_value = match &pool.token_asset_id {
-                    Some(token) => matc.value.assets[token],
-                    None => matc.value.coins,
+                let Some(token_value) = get_asset_value(&matc, &pool.token_asset_id) else {
+                    return Err(anyhow!(
+                        "no value found for asset {:?}",
+                        pool.token_asset_id
+                    ));
                 };
-                let unit_value = match &pool.unit_asset_id {
-                    Some(token) => matc.value.assets[token],
-                    None => matc.value.coins,
+                let Some(unit_value) = get_asset_value(&matc, &pool.unit_asset_id) else {
+                    return Err(anyhow!("no value found for asset {:?}", pool.unit_asset_id));
                 };
                 if unit_value == 0 {
                     return Err(anyhow!(

--- a/src/sources/minswap.rs
+++ b/src/sources/minswap.rs
@@ -5,7 +5,7 @@ use futures::{future::BoxFuture, FutureExt};
 use kupon::MatchOptions;
 use rust_decimal::Decimal;
 use tokio::time::sleep;
-use tracing::{warn, Instrument};
+use tracing::{warn, Level};
 
 use crate::config::{HydratedPool, OracleConfig};
 
@@ -54,6 +54,14 @@ impl MinswapSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        loop {
+            self.query_minswap(sink).await?;
+            sleep(Duration::from_secs(3)).await;
+        }
+    }
+
+    #[tracing::instrument(err(Debug, level = Level::WARN), skip_all)]
+    async fn query_minswap(&self, sink: &PriceSink) -> Result<()> {
         wait_for_sync(&self.client).await;
 
         let mut set = MaxConcurrencyFutureSet::new(self.max_concurrency);
@@ -66,50 +74,47 @@ impl MinswapSource {
                 .asset_id(&pool.pool.asset_id)
                 .only_unspent();
 
-            set.push(
-                async move {
-                    let mut result = client.matches(&options).await?;
-                    if result.is_empty() {
-                        return Err(anyhow!("pool not found for {}", pool.pool.token));
-                    }
-                    if result.len() > 1 {
-                        return Err(anyhow!("more than one pool found for {}", pool.pool.token));
-                    }
-                    let matc = result.remove(0);
-                    let token_value = match &pool.token_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins,
-                    };
-                    let unit_value = match &pool.unit_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins,
-                    };
-                    if unit_value == 0 {
-                        return Err(anyhow!(
-                            "Minswap reported value of {} as zero, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-                    if token_value == 0 {
-                        return Err(anyhow!(
-                            "Minswap reported value of {} as infinite, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-                    let value = Decimal::new(unit_value as i64, pool.unit_digits)
-                        / Decimal::new(token_value as i64, pool.token_digits);
-                    let tvl = Decimal::new(token_value as i64 * 2, 0);
-
-                    sink.send(PriceInfo {
-                        token: pool.pool.token.clone(),
-                        unit: pool.pool.unit.clone(),
-                        value,
-                        reliability: tvl,
-                    })?;
-                    Ok(())
+            set.push(async move {
+                let mut result = client.matches(&options).await?;
+                if result.is_empty() {
+                    return Err(anyhow!("pool not found for {}", pool.pool.token));
                 }
-                .in_current_span(),
-            );
+                if result.len() > 1 {
+                    return Err(anyhow!("more than one pool found for {}", pool.pool.token));
+                }
+                let matc = result.remove(0);
+                let token_value = match &pool.token_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins,
+                };
+                let unit_value = match &pool.unit_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins,
+                };
+                if unit_value == 0 {
+                    return Err(anyhow!(
+                        "Minswap reported value of {} as zero, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                if token_value == 0 {
+                    return Err(anyhow!(
+                        "Minswap reported value of {} as infinite, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                let value = Decimal::new(unit_value as i64, pool.unit_digits)
+                    / Decimal::new(token_value as i64, pool.token_digits);
+                let tvl = Decimal::new(token_value as i64 * 2, 0);
+
+                sink.send(PriceInfo {
+                    token: pool.pool.token.clone(),
+                    unit: pool.pool.unit.clone(),
+                    value,
+                    reliability: tvl,
+                })?;
+                Ok(())
+            });
         }
 
         while let Some(res) = set.next().await {
@@ -123,8 +128,6 @@ impl MinswapSource {
                 }
             }
         }
-
-        sleep(Duration::from_secs(3)).await;
 
         Ok(())
     }

--- a/src/sources/spectrum.rs
+++ b/src/sources/spectrum.rs
@@ -5,7 +5,7 @@ use futures::{future::BoxFuture, FutureExt};
 use kupon::MatchOptions;
 use rust_decimal::Decimal;
 use tokio::time::sleep;
-use tracing::{warn, Instrument};
+use tracing::{warn, Level};
 
 use crate::config::{HydratedPool, OracleConfig};
 
@@ -54,6 +54,14 @@ impl SpectrumSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        loop {
+            self.query_spectrum(sink).await?;
+            sleep(Duration::from_secs(3)).await;
+        }
+    }
+
+    #[tracing::instrument(err(Debug, level = Level::WARN), skip_all)]
+    async fn query_spectrum(&self, sink: &PriceSink) -> Result<()> {
         wait_for_sync(&self.client).await;
 
         let mut set = MaxConcurrencyFutureSet::new(self.max_concurrency);
@@ -66,50 +74,47 @@ impl SpectrumSource {
                 .asset_id(&pool.pool.asset_id)
                 .only_unspent();
 
-            set.push(
-                async move {
-                    let mut result = client.matches(&options).await?;
-                    if result.is_empty() {
-                        return Err(anyhow!("pool not found for {}", pool.pool.token));
-                    }
-                    if result.len() > 1 {
-                        return Err(anyhow!("more than one pool found for {}", pool.pool.token));
-                    }
-                    let matc = result.remove(0);
-                    let token_value = match &pool.token_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins,
-                    };
-                    let unit_value = match &pool.unit_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins,
-                    };
-                    if unit_value == 0 {
-                        return Err(anyhow!(
-                            "Spectrum reported value of {} as zero, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-                    if token_value == 0 {
-                        return Err(anyhow!(
-                            "Spectrum reported value of {} as infinite, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-                    let value = Decimal::new(unit_value as i64, pool.unit_digits)
-                        / Decimal::new(token_value as i64, pool.token_digits);
-                    let tvl = Decimal::new(token_value as i64 * 2, 0);
-
-                    sink.send(PriceInfo {
-                        token: pool.pool.token.clone(),
-                        unit: pool.pool.unit.clone(),
-                        value,
-                        reliability: tvl,
-                    })?;
-                    Ok(())
+            set.push(async move {
+                let mut result = client.matches(&options).await?;
+                if result.is_empty() {
+                    return Err(anyhow!("pool not found for {}", pool.pool.token));
                 }
-                .in_current_span(),
-            );
+                if result.len() > 1 {
+                    return Err(anyhow!("more than one pool found for {}", pool.pool.token));
+                }
+                let matc = result.remove(0);
+                let token_value = match &pool.token_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins,
+                };
+                let unit_value = match &pool.unit_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins,
+                };
+                if unit_value == 0 {
+                    return Err(anyhow!(
+                        "Spectrum reported value of {} as zero, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                if token_value == 0 {
+                    return Err(anyhow!(
+                        "Spectrum reported value of {} as infinite, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                let value = Decimal::new(unit_value as i64, pool.unit_digits)
+                    / Decimal::new(token_value as i64, pool.token_digits);
+                let tvl = Decimal::new(token_value as i64 * 2, 0);
+
+                sink.send(PriceInfo {
+                    token: pool.pool.token.clone(),
+                    unit: pool.pool.unit.clone(),
+                    value,
+                    reliability: tvl,
+                })?;
+                Ok(())
+            });
         }
 
         while let Some(res) = set.next().await {
@@ -123,8 +128,6 @@ impl SpectrumSource {
                 }
             }
         }
-
-        sleep(Duration::from_secs(3)).await;
 
         Ok(())
     }

--- a/src/sources/sundaeswap_kupo.rs
+++ b/src/sources/sundaeswap_kupo.rs
@@ -7,7 +7,7 @@ use kupon::{AssetId, MatchOptions};
 use pallas_primitives::conway::{BigInt, PlutusData};
 use rust_decimal::Decimal;
 use tokio::time::sleep;
-use tracing::{warn, Instrument};
+use tracing::{warn, Level};
 
 use crate::{
     config::{HydratedPool, OracleConfig},
@@ -60,6 +60,14 @@ impl SundaeSwapKupoSource {
     }
 
     async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        loop {
+            self.query_sundaeswap(sink).await?;
+            sleep(Duration::from_secs(3)).await;
+        }
+    }
+
+    #[tracing::instrument(err(Debug, level = Level::WARN), skip_all)]
+    async fn query_sundaeswap(&self, sink: &PriceSink) -> Result<()> {
         wait_for_sync(&self.client).await;
 
         let mut set = MaxConcurrencyFutureSet::new(self.max_concurrency);
@@ -72,60 +80,57 @@ impl SundaeSwapKupoSource {
                 .asset_id(&pool.pool.asset_id)
                 .only_unspent();
 
-            set.push(
-                async move {
-                    let mut result = client.matches(&options).await?;
-                    if result.is_empty() {
-                        return Err(anyhow!("pool not found for {}", pool.pool.token));
-                    }
-                    if result.len() > 1 {
-                        return Err(anyhow!("more than one pool found for {}", pool.pool.token));
-                    }
-                    let matc = result.remove(0);
-                    let Some(hash) = matc.datum else {
-                        return Err(anyhow!("no datum attached to result"));
-                    };
-                    let Some(data) = client.datum(&hash.hash).await? else {
-                        return Err(anyhow!("could not get datum for sundae token"));
-                    };
-                    let tx_fee = extract_tx_fee(&data)?;
-
-                    let token_value = match &pool.token_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins - tx_fee,
-                    };
-
-                    let unit_value = match &pool.unit_asset_id {
-                        Some(token) => matc.value.assets[token],
-                        None => matc.value.coins - tx_fee,
-                    };
-                    if unit_value == 0 {
-                        return Err(anyhow!(
-                            "SundaeSwap reported value of {} as zero, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-                    if token_value == 0 {
-                        return Err(anyhow!(
-                            "SundaeSwap reported value of {} as infinite, ignoring",
-                            pool.pool.token
-                        ));
-                    }
-
-                    let value = Decimal::new(unit_value as i64, pool.unit_digits)
-                        / Decimal::new(token_value as i64, pool.token_digits);
-                    let tvl = Decimal::new(token_value as i64 * 2, 0);
-
-                    sink.send(PriceInfo {
-                        token: pool.pool.token.clone(),
-                        unit: pool.pool.unit.clone(),
-                        value,
-                        reliability: tvl,
-                    })?;
-                    Ok(())
+            set.push(async move {
+                let mut result = client.matches(&options).await?;
+                if result.is_empty() {
+                    return Err(anyhow!("pool not found for {}", pool.pool.token));
                 }
-                .in_current_span(),
-            );
+                if result.len() > 1 {
+                    return Err(anyhow!("more than one pool found for {}", pool.pool.token));
+                }
+                let matc = result.remove(0);
+                let Some(hash) = matc.datum else {
+                    return Err(anyhow!("no datum attached to result"));
+                };
+                let Some(data) = client.datum(&hash.hash).await? else {
+                    return Err(anyhow!("could not get datum for sundae token"));
+                };
+                let tx_fee = extract_tx_fee(&data)?;
+
+                let token_value = match &pool.token_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins - tx_fee,
+                };
+
+                let unit_value = match &pool.unit_asset_id {
+                    Some(token) => matc.value.assets[token],
+                    None => matc.value.coins - tx_fee,
+                };
+                if unit_value == 0 {
+                    return Err(anyhow!(
+                        "SundaeSwap reported value of {} as zero, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                if token_value == 0 {
+                    return Err(anyhow!(
+                        "SundaeSwap reported value of {} as infinite, ignoring",
+                        pool.pool.token
+                    ));
+                }
+
+                let value = Decimal::new(unit_value as i64, pool.unit_digits)
+                    / Decimal::new(token_value as i64, pool.token_digits);
+                let tvl = Decimal::new(token_value as i64 * 2, 0);
+
+                sink.send(PriceInfo {
+                    token: pool.pool.token.clone(),
+                    unit: pool.pool.unit.clone(),
+                    value,
+                    reliability: tvl,
+                })?;
+                Ok(())
+            });
         }
 
         while let Some(res) = set.next().await {
@@ -139,8 +144,6 @@ impl SundaeSwapKupoSource {
                 }
             }
         }
-
-        sleep(Duration::from_secs(3)).await;
 
         Ok(())
     }


### PR DESCRIPTION
- If a kupo match is missing a token, return a friendly error instead of panicking
- Improve some log messages, particularly around Kupo queries
- For the sources which we "poll" (REST APIs and Kupo), make a new span for every round of polling so that logs come through