### PR TITLE
Save prices to disk, load them after restarting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/data
 /keys
 /target
 /volumes

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The oracle network is currently a set of 4 nodes, requiring agreement among 3 of
 
 This section will explain how to set up and run an oracle node, for the node operators.
 
+### Pick a data directory
+
+The oracle saves some state to disk, to help it start up more gracefully after restarting. It should have access to a writable directory where it can keep that state. By default, this is a `data` directory relative to your PWD, but you can set a `DATA_DIRECTORY` env var to change that.
+
 ### Pick a key directory
 
 The oracle uses several sets of private/public keys. By default, these are stored in a `keys` directory relative to your PWD, but you can set a `KEYS_DIRECTORY` env var to change that.

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use dashmap::DashMap;
 use num_bigint::BigUint;
 use num_integer::Integer;
+use persistence::TokenPricePersistence;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use tokio::{sync::watch::Sender, task::JoinSet, time::sleep};
 use tracing::{debug, error, warn};
@@ -27,12 +28,14 @@ pub use self::conversions::{TokenPrice, TokenPriceSource};
 use self::{conversions::TokenPriceConverter, source_adapter::SourceAdapter};
 
 mod conversions;
+mod persistence;
 mod source_adapter;
 
 pub struct PriceAggregator {
     feed_tx: Arc<Sender<Vec<PriceFeedEntry>>>,
     audit_tx: Arc<Sender<Vec<TokenPrice>>>,
     sources: Option<Vec<SourceAdapter>>,
+    persistence: TokenPricePersistence,
     config: Arc<OracleConfig>,
 }
 
@@ -68,6 +71,7 @@ impl PriceAggregator {
             feed_tx: Arc::new(feed_tx),
             audit_tx: Arc::new(audit_tx),
             sources: Some(sources),
+            persistence: TokenPricePersistence::new(&config),
             config,
         })
     }
@@ -90,7 +94,7 @@ impl PriceAggregator {
         // Every second, we report the latest values from those price maps.
         set.spawn(async move {
             loop {
-                self.report(&price_maps);
+                self.report(&price_maps).await;
                 sleep(Duration::from_secs(1)).await;
             }
         });
@@ -102,7 +106,7 @@ impl PriceAggregator {
         }
     }
 
-    fn report(&self, price_maps: &[(String, Arc<DashMap<String, PriceInfo>>)]) {
+    async fn report(&mut self, price_maps: &[(String, Arc<DashMap<String, PriceInfo>>)]) {
         let mut source_prices = vec![];
         for (source, price_map) in price_maps {
             for price in price_map.iter() {
@@ -110,11 +114,9 @@ impl PriceAggregator {
             }
         }
 
-        let converter = TokenPriceConverter::new(
-            &source_prices,
-            &self.config.synthetics,
-            &self.config.currencies,
-        );
+        let default_prices = self.persistence.previous_prices();
+        let converter =
+            TokenPriceConverter::new(&source_prices, &default_prices, &self.config.synthetics);
 
         let price_feeds = self
             .config
@@ -126,6 +128,8 @@ impl PriceAggregator {
 
         let token_values = converter.token_prices();
         self.audit_tx.send_replace(token_values);
+
+        self.persistence.save_prices(&converter).await;
     }
 
     fn compute_payload(

--- a/src/price_aggregator/persistence.rs
+++ b/src/price_aggregator/persistence.rs
@@ -1,0 +1,122 @@
+use std::{
+    collections::BTreeMap,
+    env::{self, VarError},
+    path::PathBuf,
+};
+
+use anyhow::Context;
+use minicbor::{Decode, Encode};
+use rust_decimal::Decimal;
+use tracing::{info, warn};
+
+use crate::config::OracleConfig;
+
+use super::{conversions::TokenPriceConverter, TokenPrice, TokenPriceSource};
+
+#[derive(Encode, Decode, Default)]
+struct PersistedData {
+    #[n(0)]
+    prices: Vec<PersistedTokenPrice>,
+}
+
+#[derive(Encode, Decode)]
+struct PersistedTokenPrice {
+    #[n(0)]
+    token: String,
+    /// Serialized Decimal
+    #[n(1)]
+    value: [u8; 16],
+}
+
+pub struct TokenPricePersistence {
+    filename: PathBuf,
+    prices: Vec<TokenPrice>,
+    warned_about_fs_error: bool,
+}
+
+impl TokenPricePersistence {
+    pub fn new(config: &OracleConfig) -> Self {
+        let mut filename: PathBuf = match env::var("DATA_DIRECTORY") {
+            Ok(path) => path.into(),
+            Err(VarError::NotUnicode(path)) => path.into(),
+            Err(VarError::NotPresent) => "data".into(),
+        };
+        if filename.is_relative() {
+            if let Ok(pwd) = env::current_dir() {
+                filename = pwd.join(filename);
+            }
+        }
+        let _ = std::fs::create_dir_all(&filename);
+        filename.push("prices.cbor");
+
+        let data = std::fs::read(&filename)
+            .context("file did not exist")
+            .and_then(|bytes| minicbor::decode(&bytes).context("file was not valid"))
+            .unwrap_or_else(|error| {
+                info!("Persisted data not loaded: {:#}", error);
+                PersistedData::default()
+            });
+
+        let old_prices: BTreeMap<String, Decimal> = data
+            .prices
+            .into_iter()
+            .map(|p| (p.token, Decimal::deserialize(p.value)))
+            .collect();
+        let prices = config
+            .currencies
+            .iter()
+            .map(|curr| {
+                let token = curr.name.clone();
+                let (value, source) = match old_prices.get(&token) {
+                    Some(price) => (*price, "Loaded from disk"),
+                    None => (curr.price, "Hard-coded default value"),
+                };
+                TokenPrice {
+                    token,
+                    unit: "USD".into(),
+                    value,
+                    sources: vec![TokenPriceSource {
+                        name: source.into(),
+                        value,
+                        reliability: Decimal::ONE,
+                    }],
+                }
+            })
+            .collect();
+        Self {
+            filename,
+            prices,
+            warned_about_fs_error: false,
+        }
+    }
+
+    pub async fn save_prices(&mut self, converter: &TokenPriceConverter<'_>) {
+        for price in self.prices.iter_mut() {
+            let value = converter.value_in_usd(&price.token);
+            price.value = value;
+            price.sources[0].value = value;
+        }
+        let data = PersistedData {
+            prices: self
+                .prices
+                .iter()
+                .map(|p| PersistedTokenPrice {
+                    token: p.token.clone(),
+                    value: p.value.serialize(),
+                })
+                .collect(),
+        };
+        let mut bytes = vec![];
+        minicbor::encode(data, &mut bytes).expect("infallible");
+        if let Err(error) = tokio::fs::write(&self.filename, bytes).await {
+            if !self.warned_about_fs_error {
+                warn!("Could not save price data to disk: {:#}", error);
+                self.warned_about_fs_error = true;
+            }
+        }
+    }
+
+    pub fn previous_prices(&self) -> Vec<TokenPrice> {
+        self.prices.clone()
+    }
+}


### PR DESCRIPTION
Make the oracle save prices in a `data` directory, and use those saved prices as defaults at startup.

For simplicity, we just save a USD price for each token. The price calculator uses live data whenever it can; for instance, if we have a live price for BTC/USDT but not for USDT/USD, it'll use the live BTC/USDT price and the persisted USDT/USD price, not the persisted BTC/USD price. If we didn't save a default price, it'll use the hard-coded price from `config.base.yaml`.

The app will keep working even if the `data` directory doesn't exist or isn't writable, or if the saved file is invalid or whatever.