### PR TITLE
Publish individual price feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,12 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,12 +350,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
@@ -1647,9 +1635,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.25.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
+checksum = "1936e27fffe7d8557c060eb82cb71668608cd1a5fb56b63e66d22ae8d7564321"
 dependencies = [
  "half",
  "minicbor-derive",
@@ -1657,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.15.3"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1668,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-io"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77faa2a339fcad827177a0eb020c7bbb940e66686cf4bfd9140234f91ab2d71"
+checksum = "b2bfd677b950a9bb0d57d2b1fbed8c2ca6d45ee916db3f052abce624fde870f8"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1842,7 +1830,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.1",
- "bech32 0.11.0",
+ "bech32",
  "chacha20poly1305",
  "chrono",
  "clap",
@@ -1854,6 +1842,7 @@ dependencies = [
  "frost-ed25519",
  "futures",
  "hex",
+ "itertools 0.14.0",
  "kupon",
  "minicbor",
  "minicbor-io",
@@ -1903,8 +1892,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallas-codec"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
+source = "git+https://github.com/txpipe/pallas?rev=c3aad16#c3aad160b29adce9450f34f9524938937b273270"
 dependencies = [
  "hex",
  "minicbor",
@@ -1915,8 +1903,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
+source = "git+https://github.com/txpipe/pallas?rev=c3aad16#c3aad160b29adce9450f34f9524938937b273270"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -1924,19 +1911,14 @@ dependencies = [
  "rand_core",
  "serde",
  "thiserror 1.0.69",
- "zeroize",
 ]
 
 [[package]]
 name = "pallas-primitives"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
+source = "git+https://github.com/txpipe/pallas?rev=c3aad16#c3aad160b29adce9450f34f9524938937b273270"
 dependencies = [
- "base58",
- "bech32 0.9.1",
  "hex",
- "log",
  "pallas-codec",
  "pallas-crypto",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,21 +33,9 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -68,7 +56,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "serde",
  "tokio",
  "tokio-stream",
@@ -141,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arraydeque"
@@ -176,18 +164,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -324,7 +312,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -347,9 +335,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bech32"
@@ -359,9 +347,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -389,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -399,15 +387,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -446,15 +434,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "shlex",
 ]
@@ -497,16 +485,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -522,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -532,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -544,14 +532,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -574,9 +562,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "config"
-version = "0.15.7"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26695492a475c4a091cfda61446d5ba01aac2e1dfbcd27a12fdd11aa2e32596"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -587,7 +575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "winnow 0.7.1",
+ "winnow 0.7.4",
  "yaml-rust2",
 ]
 
@@ -618,7 +606,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -692,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -713,7 +701,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.6.4",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -727,7 +715,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -746,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "debugless-unwrap"
@@ -775,7 +763,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -796,7 +784,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -810,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -843,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -870,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fiat-crypto"
@@ -882,9 +870,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -895,6 +883,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -917,12 +911,12 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.14.0",
+ "itertools",
  "postcard",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serdect",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -938,7 +932,7 @@ dependencies = [
  "document-features",
  "frost-core",
  "frost-rerandomized",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -952,7 +946,7 @@ dependencies = [
  "document-features",
  "frost-core",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1017,7 +1011,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1069,7 +1063,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1087,9 +1095,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1097,7 +1105,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1106,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1129,7 +1137,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -1137,23 +1145,23 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1184,9 +1192,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1205,12 +1213,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1218,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1301,14 +1309,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1437,7 +1446,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1473,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1483,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -1504,15 +1513,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -1552,7 +1552,7 @@ name = "kupon"
 version = "0.1.0"
 source = "git+https://github.com/SundaeSwap-finance/kupon?rev=ccc0b37#ccc0b37c43405882efde0186180bf33bcd7ee802"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
@@ -1568,15 +1568,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -1651,7 +1651,7 @@ checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1682,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "opaque-debug"
@@ -1758,32 +1758,47 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "768ee97dc5cd695a4dd4a69a0678fb42789666b5a89e8c0af48bb06c6e427120"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.12",
  "tokio",
  "tonic",
  "tracing",
@@ -1791,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1803,20 +1818,19 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.0",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1842,7 +1856,7 @@ dependencies = [
  "frost-ed25519",
  "futures",
  "hex",
- "itertools 0.14.0",
+ "itertools",
  "kupon",
  "minicbor",
  "minicbor-io",
@@ -1855,7 +1869,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pallas-crypto",
  "pallas-primitives",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "rust_decimal",
  "rustls",
@@ -1909,7 +1923,7 @@ dependencies = [
  "cryptoxide",
  "hex",
  "pallas-codec",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -1946,7 +1960,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1972,20 +1986,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1993,22 +2007,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -2017,22 +2031,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2083,36 +2097,36 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2120,15 +2134,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2153,37 +2167,39 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.3.2",
+ "rand 0.9.0",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2191,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2205,12 +2221,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -2225,8 +2247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2236,7 +2269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2245,14 +2288,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -2312,12 +2364,13 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2355,15 +2408,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2422,15 +2474,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.36.0"
+version = "1.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2444,9 +2496,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2459,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "log",
  "once_cell",
@@ -2492,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2503,15 +2555,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -2527,35 +2579,35 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2565,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -2656,7 +2708,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2676,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -2740,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2766,7 +2818,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2795,11 +2847,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2810,18 +2862,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2841,7 +2893,7 @@ checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2875,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2890,9 +2942,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2914,14 +2966,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2940,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -2956,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2973,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2994,15 +3046,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.1",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -3050,7 +3102,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3107,7 +3159,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3133,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -3194,29 +3246,28 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.0",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -3226,9 +3277,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3295,11 +3346,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -3322,7 +3373,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3339,6 +3390,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3362,7 +3422,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -3397,7 +3457,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3468,37 +3528,42 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -3507,7 +3572,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3516,7 +3581,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3525,14 +3590,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3542,10 +3623,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3554,10 +3647,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3566,10 +3671,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3578,10 +3695,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3594,11 +3723,20 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3629,16 +3767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]
 
 [[package]]
 name = "yaml-rust2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
+checksum = "818913695e83ece1f8d2a1c52d54484b7b46d0f9c06beeb2649b9da50d9b512d"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -3665,49 +3803,48 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3728,7 +3865,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3750,5 +3887,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,6 +1869,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "x25519-dalek",
 ]
@@ -3261,6 +3262,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,14 @@ num-bigint = "0.4"
 num-integer = "0.1"
 num-rational = "0.4"
 num-traits = "0.2"
-opentelemetry = "0.27"
-opentelemetry-otlp = { version = "0.27", features = ["gzip-tonic", "tls-webpki-roots"] }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry = "0.29"
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic", "gzip-tonic", "tls-webpki-roots"] }
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
 pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "c3aad16" }
 pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "c3aad16" }
 rand = "0.8.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-rust_decimal = "1.34.3"
+rust_decimal = "1"
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "tls12"] }
 serde = "1"
 serde_json = "1"
@@ -52,7 +52,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots" ]}
 tokio-util = { version = "0.7", features = ["full"] }
 tonic = "0.12"
 tracing = "0.1.40"
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ ed25519-dalek = { version = "2.1" }
 frost-ed25519 = { version = "2.1", features = ["serialization"] }
 futures = "0.3"
 hex = "0.4.3"
+itertools = "0.14"
 kupon = { git = "https://github.com/SundaeSwap-finance/kupon", rev = "ccc0b37" }
-minicbor = { version = "0.25", features = ["derive", "std"] }
-minicbor-io = { version = "0.20", features = ["async-io"] }
+minicbor = { version = "0.26", features = ["derive", "std"] }
+minicbor-io = { version = "0.21", features = ["async-io"] }
 num-bigint = "0.4"
 num-integer = "0.1"
 num-rational = "0.4"
@@ -37,8 +38,8 @@ num-traits = "0.2"
 opentelemetry = "0.27"
 opentelemetry-otlp = { version = "0.27", features = ["gzip-tonic", "tls-webpki-roots"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
-pallas-crypto = "0.32"
-pallas-primitives = "0.32"
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "c3aad16" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "c3aad16" }
 rand = "0.8.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rust_decimal = "1.34.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tonic = "0.12"
 tracing = "0.1.40"
 tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 x25519-dalek = { version = "2" }
 

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -177,6 +177,9 @@ currencies:
     digits: 6
   - name: XAUt
     digits: 6
+feeds:
+  currencies:
+    - ADA
 binance:
   tokens:
     - token: ADA

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,7 +16,7 @@ use crate::{
     config::OracleConfig,
     network::NodeId,
     price_aggregator::TokenPrice,
-    signature_aggregator::{Payload, TimestampedPayloadEntry},
+    signature_aggregator::{Payload, SyntheticPayloadEntry},
 };
 
 #[derive(Clone, Serialize)]
@@ -105,7 +105,7 @@ async fn report_all_prices(State(state): State<APIState>) -> impl IntoResponse {
 
 #[allow(clippy::large_enum_variant)]
 pub enum Response {
-    Ok(TimestampedPayloadEntry),
+    Ok(SyntheticPayloadEntry),
     NotFound,
 }
 impl IntoResponse for Response {
@@ -125,9 +125,9 @@ async fn report_payload(
 ) -> impl IntoResponse {
     let payload = state.payload_source.borrow().clone();
     match payload
-        .entries
+        .synthetics
         .iter()
-        .find(|&p| p.entry.synthetic == synthetic)
+        .find(|&p| p.synthetic == synthetic)
     {
         Some(entry) => Response::Ok(entry.clone()),
         None => Response::NotFound,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use config::{Config, Environment, File, FileFormat};
 use ed25519::{pkcs8::DecodePublicKey, PublicKeyBytes};
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use itertools::izip;
 use kupon::AssetId;
 use rust_decimal::Decimal;
 use serde::Deserialize;
@@ -283,17 +282,7 @@ pub struct CurrencyConfig {
 pub struct FeedConfig {
     pub currencies: Vec<String>,
 }
-impl FeedConfig {
-    pub fn all_feeds(&self) -> Vec<Feed> {
-        izip!(&self.currencies, [false, true], [false, true])
-            .map(|(currency, invert, smooth)| Feed {
-                currency: currency.clone(),
-                invert,
-                smooth,
-            })
-            .collect()
-    }
-}
+
 pub struct Feed {
     /// The token this feed is for.
     pub currency: String,
@@ -301,17 +290,6 @@ pub struct Feed {
     pub invert: bool,
     /// If true, this feed applies GEMA smoothing.
     pub smooth: bool,
-}
-
-impl Feed {
-    pub fn name(&self) -> String {
-        format!(
-            "{}/{}#{}",
-            if self.invert { "USD" } else { &self.currency },
-            if self.invert { &self.currency } else { "USD" },
-            if self.smooth { "GEMA" } else { "RAW" },
-        )
-    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ struct RawOracleConfig {
     pub use_persisted_prices: bool,
     pub max_synthetic_divergence: Decimal,
     pub publish_url: Option<String>,
+    pub publish_feed_base_url: Option<String>,
     pub logs: RawLogConfig,
     pub frost_address: Option<String>,
     pub keygen: KeygenConfig,
@@ -67,6 +68,7 @@ pub struct OracleConfig {
     pub use_persisted_prices: bool,
     pub max_synthetic_divergence: Decimal,
     pub publish_url: Option<String>,
+    pub publish_feed_base_url: Option<String>,
     pub logs: LogConfig,
     pub frost_address: Option<String>,
     pub keygen: KeygenConfig,
@@ -159,6 +161,11 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             uptrace_dsn: raw.logs.uptrace_dsn,
         };
 
+        let publish_feed_base_url = raw.publish_feed_base_url.or_else(|| {
+            let base_url = raw.publish_url.as_ref()?;
+            Some(base_url.strip_suffix("/oraclePrices")?.to_string())
+        });
+
         Ok(Self {
             id,
             label,
@@ -175,6 +182,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             use_persisted_prices: raw.use_persisted_prices,
             max_synthetic_divergence: raw.max_synthetic_divergence,
             publish_url: raw.publish_url,
+            publish_feed_base_url,
             logs,
             frost_address: raw.frost_address,
             keygen: raw.keygen,

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,15 +291,6 @@ pub struct FeedConfig {
     pub currencies: Vec<String>,
 }
 
-pub struct Feed {
-    /// The token this feed is for.
-    pub currency: String,
-    /// If true, this is USD/token. If false, token/USD.
-    pub invert: bool,
-    /// If true, this feed applies GEMA smoothing.
-    pub smooth: bool,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct BinanceConfig {
     pub tokens: Vec<BinanceTokenConfig>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,8 +162,8 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
         };
 
         let publish_feed_base_url = raw.publish_feed_base_url.or_else(|| {
-            let base_url = raw.publish_url.as_ref()?;
-            Some(base_url.strip_suffix("/oraclePrices")?.to_string())
+            let base_url = raw.publish_url.as_ref()?.strip_suffix("/oraclePrices")?;
+            Some(format!("{base_url}/oracles"))
         });
 
         Ok(Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,10 @@ struct Node {
 impl Node {
     pub fn new(config: Arc<OracleConfig>) -> Result<Self> {
         let (leader_sink, leader_source) = watch::channel(RaftLeader::Unknown);
-        let (price_sink, price_source) = watch::channel(PriceData { synthetics: vec![] });
+        let (price_sink, price_source) = watch::channel(PriceData {
+            synthetics: vec![],
+            generics: vec![],
+        });
         let (price_audit_sink, price_audit_source) = watch::channel(vec![]);
         let (raft_client, raft_source) = RaftClient::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use oracles::{
     instrumentation,
     network::Network,
     price_aggregator::PriceAggregator,
+    price_feed::PriceData,
     publisher::Publisher,
     raft::{Raft, RaftClient, RaftLeader},
     signature_aggregator::SignatureAggregator,
@@ -45,7 +46,7 @@ struct Node {
 impl Node {
     pub fn new(config: Arc<OracleConfig>) -> Result<Self> {
         let (leader_sink, leader_source) = watch::channel(RaftLeader::Unknown);
-        let (price_feed_sink, price_feed_source) = watch::channel(vec![]);
+        let (price_sink, price_source) = watch::channel(PriceData { synthetics: vec![] });
         let (price_audit_sink, price_audit_source) = watch::channel(vec![]);
         let (raft_client, raft_source) = RaftClient::new();
 
@@ -63,7 +64,7 @@ impl Node {
             &config,
             &mut network,
             leader_sink,
-            price_feed_source.clone(),
+            price_source.clone(),
             raft_source,
         );
 
@@ -72,15 +73,15 @@ impl Node {
                 &config,
                 &mut network,
                 raft_client,
-                price_feed_source,
+                price_source,
                 leader_source,
             )?
         } else {
-            SignatureAggregator::single(&config, raft_client, price_feed_source, leader_source)?
+            SignatureAggregator::single(&config, raft_client, price_source, leader_source)?
         };
 
         let price_aggregator = PriceAggregator::new(
-            price_feed_sink,
+            price_sink,
             price_audit_sink,
             payload_source.clone(),
             config.clone(),

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -192,7 +192,11 @@ impl PriceAggregator {
             .iter()
             .filter_map(|s| self.compute_synthetic_payload(s, &converter))
             .collect();
-        self.price_sink.send_replace(PriceData { synthetics });
+        let generics = vec![]; // TODO
+        self.price_sink.send_replace(PriceData {
+            synthetics,
+            generics,
+        });
 
         let token_values = converter.token_prices();
         self.audit_sink.send_replace(token_values);

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -316,31 +316,31 @@ impl PriceAggregator {
         let Some(price) = converter.value_in_usd(currency) else {
             return feeds;
         };
-        let usd_per_token = to_int(&price);
-        let token_per_usd = to_int(&(BigRational::one() / &price));
+        let token_usd = to_int(&price);
+        let usd_token = to_int(&(BigRational::one() / &price));
 
         feeds.push(GenericPriceFeed {
-            price: usd_per_token.clone(),
-            name: format!("USD/{currency}#RAW"),
-            timestamp,
-        });
-        feeds.push(GenericPriceFeed {
-            price: token_per_usd.clone(),
+            price: token_usd.clone(),
             name: format!("{currency}/USD#RAW"),
             timestamp,
         });
-
-        let usd_per_token_gema_feed = format!("USD/{currency}#GEMA");
         feeds.push(GenericPriceFeed {
-            price: self.apply_gema(&usd_per_token_gema_feed, usd_per_token),
-            name: usd_per_token_gema_feed,
+            price: usd_token.clone(),
+            name: format!("USD/{currency}#RAW"),
             timestamp,
         });
 
-        let token_per_usd_gema_feed = format!("{currency}/USD#GEMA");
+        let token_usd_gema = format!("{currency}/USD#GEMA");
         feeds.push(GenericPriceFeed {
-            price: self.apply_gema(&token_per_usd_gema_feed, token_per_usd),
-            name: token_per_usd_gema_feed,
+            price: self.apply_gema(&token_usd_gema, token_usd),
+            name: token_usd_gema,
+            timestamp,
+        });
+
+        let usd_token_gema_feed = format!("USD/{currency}#GEMA");
+        feeds.push(GenericPriceFeed {
+            price: self.apply_gema(&usd_token_gema_feed, usd_token),
+            name: usd_token_gema_feed,
             timestamp,
         });
 

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -309,7 +309,7 @@ impl PriceAggregator {
             .expect("it is after 1970")
             .as_millis() as u64;
         let to_int = |price: &BigRational| {
-            let int_price: BigInt = (price.numer() * 1_000_000) / price.denom();
+            let int_price: BigInt = (price.numer() * 10_000_000) / price.denom();
             int_price.to_biguint().unwrap()
         };
 

--- a/src/price_aggregator/gema.rs
+++ b/src/price_aggregator/gema.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use num_rational::BigRational;
+use num_bigint::BigUint;
+use num_rational::{BigRational, Ratio};
 use num_traits::One;
 
 pub struct GemaCalculator {
@@ -15,7 +16,7 @@ impl GemaCalculator {
             round_duration,
         }
     }
-    pub fn smooth(
+    pub fn smooth_synthetic_price(
         &self,
         time_elapsed: Duration,
         prev_prices: &[BigRational],
@@ -55,12 +56,55 @@ impl GemaCalculator {
             })
             .collect()
     }
+
+    pub fn smooth_price(
+        &self,
+        time_elapsed: Duration,
+        prev_price: &BigUint,
+        price: BigUint,
+    ) -> BigUint {
+        // The "time_elapsed" is between the end of some round (when results were published)
+        // and the start of this round (when prices are gathered).
+        // Approximate how many periods have elapsed,
+        // and round so that slight timing differences don't affect the output
+        let periods_elapsed = time_elapsed.as_secs_f64() / self.round_duration.as_secs_f64();
+        let periods_elapsed = periods_elapsed.round();
+
+        let periods = (self.periods as f64) + periods_elapsed;
+        let factor: f64 = 2.0 / (periods + 1.0).max(2.0);
+
+        let Some(prev_price_weight) = Ratio::from_float(factor) else {
+            // this only happens if an NaN or Infinity sneaks into our calculations somewhere
+            return price;
+        };
+        let Some(prev_numer) = prev_price_weight.numer().to_biguint() else {
+            return price;
+        };
+        let Some(prev_denom) = prev_price_weight.denom().to_biguint() else {
+            return price;
+        };
+
+        let curr_price_weight = BigRational::one() - &prev_price_weight;
+        let Some(curr_numer) = curr_price_weight.numer().to_biguint() else {
+            return price;
+        };
+        let Some(curr_denom) = curr_price_weight.denom().to_biguint() else {
+            return price;
+        };
+
+        if price < *prev_price {
+            // Reflect downturns immediately
+            return price;
+        }
+        (price * curr_numer / curr_denom) + (prev_price * prev_numer / prev_denom)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use num_bigint::BigUint;
     use num_rational::BigRational;
 
     use super::GemaCalculator;
@@ -78,7 +122,7 @@ mod tests {
         let prev_prices = vec![rational(1, 1), rational(1, 1)];
         let curr_prices = vec![rational(2, 1), rational(1, 2)];
 
-        let prices = calculator.smooth(round_duration, &prev_prices, curr_prices);
+        let prices = calculator.smooth_synthetic_price(round_duration, &prev_prices, curr_prices);
         assert_eq!(prices, vec![rational(3, 2), rational(1, 2)]);
     }
 
@@ -92,15 +136,35 @@ mod tests {
         let curr_prices = vec![rational(2, 1), rational(1, 2)];
 
         // both these durations round to 5 seconds (one round)
-        let prices_4sec =
-            calculator.smooth(Duration::from_secs(4), &prev_prices, curr_prices.clone());
-        let prices_6sec =
-            calculator.smooth(Duration::from_secs(6), &prev_prices, curr_prices.clone());
+        let prices_4sec = calculator.smooth_synthetic_price(
+            Duration::from_secs(4),
+            &prev_prices,
+            curr_prices.clone(),
+        );
+        let prices_6sec = calculator.smooth_synthetic_price(
+            Duration::from_secs(6),
+            &prev_prices,
+            curr_prices.clone(),
+        );
         assert_eq!(prices_4sec, prices_6sec);
 
         // this duration rounds to 10 seconds (two rounds),
         // so we should assume that we missed a round and not smooth as much
-        let prices_8sec = calculator.smooth(Duration::from_secs(8), &prev_prices, curr_prices);
+        let prices_8sec =
+            calculator.smooth_synthetic_price(Duration::from_secs(8), &prev_prices, curr_prices);
         assert!(prices_6sec[0] < prices_8sec[0]);
+    }
+
+    #[test]
+    fn should_smooth_individual_price() {
+        let periods = 2;
+        let round_duration = Duration::from_secs(5);
+        let calculator = GemaCalculator::new(periods, round_duration);
+
+        let prev_price = BigUint::from(1000000u64);
+        let curr_price = BigUint::from(2000000u64);
+
+        let price = calculator.smooth_price(round_duration, &prev_price, curr_price);
+        assert_eq!(price, BigUint::from(1500000u64));
     }
 }

--- a/src/price_feed.rs
+++ b/src/price_feed.rs
@@ -1,23 +1,21 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 pub use codec::{cbor_encode_in_list, deserialize, serialize, PlutusCompatible};
-use codec::{decode_enum, decode_struct, encode_enum, encode_struct};
+use codec::{decode_struct, encode_struct};
+pub use generic::GenericPriceFeed;
 use minicbor::{decode, encode, CborLen, Decode, Decoder, Encode, Encoder};
-use num_bigint::BigUint;
-use num_rational::BigRational;
 use pallas_primitives::PlutusData;
+pub use synthetic::{
+    IntervalBound, IntervalBoundType, SyntheticPriceData, SyntheticPriceFeed, Validity,
+};
 
 mod codec;
+mod generic;
+mod synthetic;
 
 #[derive(Clone, Debug)]
 pub struct PriceData {
     pub synthetics: Vec<SyntheticPriceData>,
-}
-
-#[derive(Clone, Debug)]
-pub struct SyntheticPriceData {
-    pub price: BigRational,
-    pub feed: SyntheticPriceFeed,
 }
 
 #[derive(Decode, Encode, Clone, Debug)]
@@ -26,6 +24,9 @@ pub struct SignedEntries {
     pub timestamp: SystemTime,
     #[n(1)]
     pub synthetics: Vec<SyntheticEntry>,
+    #[n(2)]
+    #[cbor(default)]
+    pub generics: Vec<GenericEntry>,
 }
 
 #[derive(Decode, Encode, Clone, Debug)]
@@ -36,6 +37,14 @@ pub struct SyntheticEntry {
     pub feed: Signed<SyntheticPriceFeed>,
     #[n(2)]
     pub timestamp: Option<SystemTime>,
+}
+
+#[derive(Decode, Encode, Clone, Debug)]
+pub struct GenericEntry {
+    #[n(0)]
+    pub feed: Signed<GenericPriceFeed>,
+    #[n(1)]
+    pub timestamp: SystemTime,
 }
 
 #[derive(Clone, Debug)]
@@ -85,209 +94,5 @@ impl<C, T: PlutusCompatible> CborLen<C> for Signed<T> {
         let mut bytes = vec![];
         minicbor::encode_with(self, &mut bytes, ctx).expect("infallible");
         bytes.len()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SyntheticPriceFeed {
-    pub collateral_names: Option<Vec<String>>,
-    pub collateral_prices: Vec<BigUint>,
-    pub synthetic: String,
-    pub denominator: BigUint,
-    pub validity: Validity,
-}
-
-impl PlutusCompatible for SyntheticPriceFeed {
-    fn to_plutus(&self) -> PlutusData {
-        encode_struct(vec![
-            self.collateral_prices.to_plutus(),
-            self.synthetic.to_plutus(),
-            self.denominator.to_plutus(),
-            self.validity.to_plutus(),
-        ])
-    }
-
-    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
-        let [encoded_collateral_prices, encoded_synthetic, encoded_denominator, encoded_validity] =
-            decode_struct(data)?;
-
-        let collateral_prices = Vec::from_plutus(encoded_collateral_prices)?;
-        let synthetic = String::from_plutus(encoded_synthetic)?;
-        let denominator = BigUint::from_plutus(encoded_denominator)?;
-        let validity = Validity::from_plutus(encoded_validity)?;
-        Ok(SyntheticPriceFeed {
-            collateral_names: None,
-            collateral_prices,
-            synthetic,
-            denominator,
-            validity,
-        })
-    }
-}
-
-impl<C> Encode<C> for SyntheticPriceFeed {
-    fn encode<W: encode::Write>(
-        &self,
-        e: &mut Encoder<W>,
-        ctx: &mut C,
-    ) -> Result<(), encode::Error<W::Error>> {
-        self.to_plutus().encode(e, ctx)
-    }
-}
-
-impl<'b, C> Decode<'b, C> for SyntheticPriceFeed {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        Self::from_plutus(d.decode_with(ctx)?)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Validity {
-    pub lower_bound: IntervalBound,
-    pub upper_bound: IntervalBound,
-}
-impl Default for Validity {
-    fn default() -> Self {
-        Self {
-            lower_bound: IntervalBound::start_of_time(false),
-            upper_bound: IntervalBound::end_of_time(false),
-        }
-    }
-}
-
-impl PlutusCompatible for Validity {
-    fn to_plutus(&self) -> PlutusData {
-        encode_struct(vec![
-            self.lower_bound.to_plutus(),
-            self.upper_bound.to_plutus(),
-        ])
-    }
-
-    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
-        let [encoded_lower_bound, encoded_upper_bound] = decode_struct(data)?;
-        let lower_bound = IntervalBound::from_plutus(encoded_lower_bound)?;
-        let upper_bound = IntervalBound::from_plutus(encoded_upper_bound)?;
-        Ok(Validity {
-            lower_bound,
-            upper_bound,
-        })
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct IntervalBound {
-    pub bound_type: IntervalBoundType,
-    pub is_inclusive: bool,
-}
-impl IntervalBound {
-    pub fn start_of_time(is_inclusive: bool) -> Self {
-        Self {
-            bound_type: IntervalBoundType::NegativeInfinity,
-            is_inclusive,
-        }
-    }
-    pub fn end_of_time(is_inclusive: bool) -> Self {
-        Self {
-            bound_type: IntervalBoundType::PositiveInfinity,
-            is_inclusive,
-        }
-    }
-    pub fn moment(moment: SystemTime, is_inclusive: bool) -> Self {
-        let timestamp = moment
-            .duration_since(UNIX_EPOCH)
-            .expect("it is currently after 1970")
-            .as_millis() as u64;
-        Self::unix_timestamp(timestamp, is_inclusive)
-    }
-    pub fn unix_timestamp(timestamp: u64, is_inclusive: bool) -> Self {
-        Self {
-            bound_type: IntervalBoundType::Finite(timestamp),
-            is_inclusive,
-        }
-    }
-}
-
-impl PlutusCompatible for IntervalBound {
-    fn to_plutus(&self) -> PlutusData {
-        encode_struct(vec![
-            self.bound_type.to_plutus(),
-            self.is_inclusive.to_plutus(),
-        ])
-    }
-
-    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
-        let [encoded_bound_type, encoded_is_inclusive] = decode_struct(data)?;
-        let bound_type = IntervalBoundType::from_plutus(encoded_bound_type)?;
-        let is_inclusive = bool::from_plutus(encoded_is_inclusive)?;
-        Ok(IntervalBound {
-            bound_type,
-            is_inclusive,
-        })
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum IntervalBoundType {
-    NegativeInfinity,
-    #[allow(unused)]
-    Finite(u64),
-    PositiveInfinity,
-}
-impl PlutusCompatible for IntervalBoundType {
-    fn to_plutus(&self) -> PlutusData {
-        match self {
-            Self::NegativeInfinity => encode_enum(0, None),
-            Self::Finite(val) => encode_enum(1, Some(val.to_plutus())),
-            Self::PositiveInfinity => encode_enum(2, None),
-        }
-    }
-    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
-        match decode_enum(data)? {
-            (0, None) => Ok(IntervalBoundType::NegativeInfinity),
-            (1, Some(val)) => {
-                let time = u64::from_plutus(val)?;
-                Ok(IntervalBoundType::Finite(time))
-            }
-            (2, None) => Ok(IntervalBoundType::PositiveInfinity),
-            _ => Err(decode::Error::message("Unexpected IntervalBoundType value")),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use num_bigint::BigUint;
-
-    use super::{deserialize, serialize, IntervalBound, SyntheticPriceFeed, Validity};
-
-    #[test]
-    fn should_serialize_infinite_validity() {
-        let validity = Validity::default();
-        let round_tripped = deserialize(&serialize(&validity)).unwrap();
-        assert_eq!(validity, round_tripped);
-    }
-
-    #[test]
-    fn should_serialize_finite_validity() {
-        let validity = Validity {
-            lower_bound: IntervalBound::unix_timestamp(1000000, true),
-            upper_bound: IntervalBound::unix_timestamp(1005000, true),
-        };
-        let round_tripped = deserialize(&serialize(&validity)).unwrap();
-        assert_eq!(validity, round_tripped);
-    }
-
-    #[test]
-    fn should_serialize_price_feed() {
-        // Note: the only thing that doesn't round trip is collateral_names
-        let feed = SyntheticPriceFeed {
-            collateral_names: None,
-            collateral_prices: vec![BigUint::from(1u32), BigUint::from(u128::MAX) * 2u32],
-            synthetic: "HIPI".into(),
-            denominator: BigUint::from(31337u32),
-            validity: Validity::default(),
-        };
-        let round_tripped = deserialize(&serialize(&feed)).unwrap();
-        assert_eq!(feed, round_tripped);
     }
 }

--- a/src/price_feed.rs
+++ b/src/price_feed.rs
@@ -1,29 +1,23 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use minicbor::{
-    data::Type,
-    decode,
-    encode::{self, Write},
-    CborLen, Decode, Decoder, Encode, Encoder,
-};
+pub use codec::{cbor_encode_in_list, deserialize, serialize, PlutusCompatible};
+use codec::{decode_enum, decode_struct, encode_enum, encode_struct};
+use minicbor::{decode, encode, CborLen, Decode, Decoder, Encode, Encoder};
 use num_bigint::BigUint;
 use num_rational::BigRational;
-use pallas_primitives::{
-    conway::{BigInt, Constr, PlutusData},
-    MaybeIndefArray,
-};
-use rust_decimal::prelude::ToPrimitive;
+use pallas_primitives::PlutusData;
 
-pub fn serialize<T: Into<PlutusData>>(data: T) -> Vec<u8> {
-    let plutus: PlutusData = data.into();
-    let mut encoder = Encoder::new(vec![]);
-    encoder.encode(&plutus).unwrap(); //infallible
-    encoder.into_writer()
+mod codec;
+
+#[derive(Clone, Debug)]
+pub struct PriceData {
+    pub synthetics: Vec<SyntheticPriceData>,
 }
 
-pub fn deserialize<'a, T: Decode<'a, ()>>(bytes: &'a [u8]) -> Result<T, minicbor::decode::Error> {
-    let mut decoder = Decoder::new(bytes);
-    decoder.decode()
+#[derive(Clone, Debug)]
+pub struct SyntheticPriceData {
+    pub price: BigRational,
+    pub feed: SyntheticPriceFeed,
 }
 
 #[derive(Decode, Encode, Clone, Debug)]
@@ -31,62 +25,62 @@ pub struct SignedEntries {
     #[n(0)]
     pub timestamp: SystemTime,
     #[n(1)]
-    pub entries: Vec<SignedEntry>,
+    pub synthetics: Vec<SyntheticEntry>,
 }
 
 #[derive(Decode, Encode, Clone, Debug)]
-pub struct SignedEntry {
+pub struct SyntheticEntry {
     #[n(0)]
     pub price: f64,
     #[n(1)]
-    pub data: SignedPriceFeed,
+    pub feed: Signed<SyntheticPriceFeed>,
     #[n(2)]
     pub timestamp: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug)]
-pub struct PriceFeedEntry {
-    pub price: BigRational,
-    pub data: PriceFeed,
-}
-
-#[derive(Clone, Debug)]
-pub struct SignedPriceFeed {
-    pub data: PriceFeed,
+pub struct Signed<T> {
+    pub data: T,
     pub signature: Vec<u8>,
 }
-impl From<&SignedPriceFeed> for PlutusData {
-    fn from(value: &SignedPriceFeed) -> Self {
-        let encoded_data: PlutusData = (&value.data).into();
+
+impl<T: PlutusCompatible> PlutusCompatible for Signed<T> {
+    fn to_plutus(&self) -> PlutusData {
+        let encoded_data = self.data.to_plutus();
         encode_struct(vec![
             encoded_data,
-            PlutusData::BoundedBytes(value.signature.clone().into()),
+            PlutusData::BoundedBytes(self.signature.clone().into()),
         ])
     }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_data, encoded_signature] = decode_struct(data)?;
+        let data = T::from_plutus(encoded_data)?;
+        let PlutusData::BoundedBytes(sig_bytes) = encoded_signature else {
+            return Err(minicbor::decode::Error::message("Unexpected signature"));
+        };
+        let signature = sig_bytes.into();
+        Ok(Self { data, signature })
+    }
 }
-impl<C> Encode<C> for SignedPriceFeed {
-    fn encode<W: Write>(
+
+impl<C, T: PlutusCompatible> Encode<C> for Signed<T> {
+    fn encode<W: encode::Write>(
         &self,
         e: &mut Encoder<W>,
         ctx: &mut C,
     ) -> Result<(), encode::Error<W::Error>> {
-        let plutus_data: PlutusData = self.into();
-        plutus_data.encode(e, ctx)
+        self.to_plutus().encode(e, ctx)
     }
 }
-impl<'b, C> Decode<'b, C> for SignedPriceFeed {
+
+impl<'b, C, T: PlutusCompatible> Decode<'b, C> for Signed<T> {
     fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        decode_struct_begin(d)?;
-
-        let data = d.decode_with(ctx)?;
-        let signature = d.bytes()?.to_vec();
-
-        decode_struct_end(d)?;
-
-        Ok(SignedPriceFeed { data, signature })
+        Self::from_plutus(d.decode_with(ctx)?)
     }
 }
-impl<C> CborLen<C> for SignedPriceFeed {
+
+impl<C, T: PlutusCompatible> CborLen<C> for Signed<T> {
     fn cbor_len(&self, ctx: &mut C) -> usize {
         let mut bytes = vec![];
         minicbor::encode_with(self, &mut bytes, ctx).expect("infallible");
@@ -95,64 +89,55 @@ impl<C> CborLen<C> for SignedPriceFeed {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PriceFeed {
+pub struct SyntheticPriceFeed {
     pub collateral_names: Option<Vec<String>>,
     pub collateral_prices: Vec<BigUint>,
     pub synthetic: String,
     pub denominator: BigUint,
     pub validity: Validity,
 }
-impl From<&PriceFeed> for PlutusData {
-    fn from(value: &PriceFeed) -> Self {
+
+impl PlutusCompatible for SyntheticPriceFeed {
+    fn to_plutus(&self) -> PlutusData {
         encode_struct(vec![
-            PlutusData::Array(MaybeIndefArray::Indef(
-                value.collateral_prices.iter().map(encode_bigint).collect(),
-            )),
-            PlutusData::BoundedBytes(value.synthetic.as_bytes().to_vec().into()),
-            encode_bigint(&value.denominator),
-            value.validity.into(),
+            self.collateral_prices.to_plutus(),
+            self.synthetic.to_plutus(),
+            self.denominator.to_plutus(),
+            self.validity.to_plutus(),
         ])
     }
-}
 
-impl<C> Encode<C> for PriceFeed {
-    fn encode<W: Write>(
-        &self,
-        e: &mut Encoder<W>,
-        ctx: &mut C,
-    ) -> Result<(), encode::Error<W::Error>> {
-        let plutus_data: PlutusData = self.into();
-        plutus_data.encode(e, ctx)
-    }
-}
+    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_collateral_prices, encoded_synthetic, encoded_denominator, encoded_validity] =
+            decode_struct(data)?;
 
-impl<'b, C> Decode<'b, C> for PriceFeed {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        decode_struct_begin(d)?;
-
-        let mut collateral_prices = vec![];
-        let cols: Vec<BigInt> = d.decode_with(ctx)?;
-        for col in cols {
-            collateral_prices.push(decode_bigint(&col)?);
-        }
-
-        let synthetic = std::str::from_utf8(d.bytes()?)
-            .map_err(|err| decode::Error::message(err.to_string()))?
-            .to_string();
-
-        let denominator = decode_bigint(&d.decode_with(ctx)?)?;
-
-        let validity = d.decode_with(ctx)?;
-
-        decode_struct_end(d)?;
-
-        Ok(PriceFeed {
+        let collateral_prices = Vec::from_plutus(encoded_collateral_prices)?;
+        let synthetic = String::from_plutus(encoded_synthetic)?;
+        let denominator = BigUint::from_plutus(encoded_denominator)?;
+        let validity = Validity::from_plutus(encoded_validity)?;
+        Ok(SyntheticPriceFeed {
             collateral_names: None,
             collateral_prices,
             synthetic,
             denominator,
             validity,
         })
+    }
+}
+
+impl<C> Encode<C> for SyntheticPriceFeed {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), encode::Error<W::Error>> {
+        self.to_plutus().encode(e, ctx)
+    }
+}
+
+impl<'b, C> Decode<'b, C> for SyntheticPriceFeed {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
+        Self::from_plutus(d.decode_with(ctx)?)
     }
 }
 
@@ -169,18 +154,19 @@ impl Default for Validity {
         }
     }
 }
-impl From<Validity> for PlutusData {
-    fn from(val: Validity) -> Self {
-        encode_struct(vec![val.lower_bound.into(), val.upper_bound.into()])
-    }
-}
-impl<'b, C> Decode<'b, C> for Validity {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        decode_struct_begin(d)?;
-        let lower_bound = d.decode_with(ctx)?;
-        let upper_bound = d.decode_with(ctx)?;
-        decode_struct_end(d)?;
 
+impl PlutusCompatible for Validity {
+    fn to_plutus(&self) -> PlutusData {
+        encode_struct(vec![
+            self.lower_bound.to_plutus(),
+            self.upper_bound.to_plutus(),
+        ])
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let [encoded_lower_bound, encoded_upper_bound] = decode_struct(data)?;
+        let lower_bound = IntervalBound::from_plutus(encoded_lower_bound)?;
+        let upper_bound = IntervalBound::from_plutus(encoded_upper_bound)?;
         Ok(Validity {
             lower_bound,
             upper_bound,
@@ -220,25 +206,19 @@ impl IntervalBound {
         }
     }
 }
-impl From<IntervalBound> for PlutusData {
-    fn from(val: IntervalBound) -> Self {
+
+impl PlutusCompatible for IntervalBound {
+    fn to_plutus(&self) -> PlutusData {
         encode_struct(vec![
-            val.bound_type.into(),
-            encode_enum(if val.is_inclusive { 1 } else { 0 }, None),
+            self.bound_type.to_plutus(),
+            self.is_inclusive.to_plutus(),
         ])
     }
-}
-impl<'b, C> Decode<'b, C> for IntervalBound {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        decode_struct_begin(d)?;
-        let bound_type = d.decode_with(ctx)?;
-        let is_inclusive: bool = match decode_enum::<C, ()>(d, ctx)? {
-            (1, _) => true,
-            (0, _) => false,
-            _ => return Err(decode::Error::message("Unexpected bool value")),
-        };
-        decode_struct_end(d)?;
 
+    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_bound_type, encoded_is_inclusive] = decode_struct(data)?;
+        let bound_type = IntervalBoundType::from_plutus(encoded_bound_type)?;
+        let is_inclusive = bool::from_plutus(encoded_is_inclusive)?;
         Ok(IntervalBound {
             bound_type,
             is_inclusive,
@@ -253,120 +233,37 @@ pub enum IntervalBoundType {
     Finite(u64),
     PositiveInfinity,
 }
-impl From<IntervalBoundType> for PlutusData {
-    fn from(val: IntervalBoundType) -> Self {
-        match val {
-            IntervalBoundType::NegativeInfinity => encode_enum(0, None),
-            IntervalBoundType::Finite(val) => encode_enum(1, Some(encode_bigint(&val.into()))),
-            IntervalBoundType::PositiveInfinity => encode_enum(2, None),
+impl PlutusCompatible for IntervalBoundType {
+    fn to_plutus(&self) -> PlutusData {
+        match self {
+            Self::NegativeInfinity => encode_enum(0, None),
+            Self::Finite(val) => encode_enum(1, Some(val.to_plutus())),
+            Self::PositiveInfinity => encode_enum(2, None),
         }
     }
-}
-impl<'b, C> Decode<'b, C> for IntervalBoundType {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
-        match decode_enum(d, ctx)? {
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        match decode_enum(data)? {
             (0, None) => Ok(IntervalBoundType::NegativeInfinity),
-            (1, Some(val)) => Ok(IntervalBoundType::Finite(val)),
+            (1, Some(val)) => {
+                let time = u64::from_plutus(val)?;
+                Ok(IntervalBoundType::Finite(time))
+            }
             (2, None) => Ok(IntervalBoundType::PositiveInfinity),
             _ => Err(decode::Error::message("Unexpected IntervalBoundType value")),
         }
     }
 }
 
-const CBOR_VARIANT_0: u64 = 121;
-
-fn encode_bigint(value: &BigUint) -> PlutusData {
-    PlutusData::BigInt(match value.to_i64() {
-        Some(val) => BigInt::Int(val.into()),
-        None => BigInt::BigUInt(value.to_bytes_be().into()),
-    })
-}
-fn decode_bigint(value: &BigInt) -> Result<BigUint, decode::Error> {
-    match value {
-        BigInt::Int(val) => {
-            let raw: i128 = (*val).into();
-            Ok(BigUint::from(raw as u128))
-        }
-        BigInt::BigUInt(val) => Ok(BigUint::from_bytes_be(val)),
-        BigInt::BigNInt(_) => Err(decode::Error::message("Unexpected signed integer")),
-    }
-}
-
-fn encode_struct(fields: Vec<PlutusData>) -> PlutusData {
-    PlutusData::Constr(Constr {
-        tag: CBOR_VARIANT_0,
-        any_constructor: None,
-        fields: MaybeIndefArray::Indef(fields),
-    })
-}
-
-fn decode_struct_begin(d: &mut Decoder) -> Result<(), decode::Error> {
-    let tag = d.tag()?;
-    if tag.as_u64() != CBOR_VARIANT_0 {
-        return Err(decode::Error::message("Invalid plutus struct tag"));
-    };
-    d.array()?;
-    Ok(())
-}
-fn decode_struct_end(d: &mut Decoder) -> Result<(), decode::Error> {
-    let Type::Break = d.datatype()? else {
-        return Err(decode::Error::message("Expected end of struct"));
-    };
-    d.skip()
-}
-
-fn encode_enum(variant: u64, value: Option<PlutusData>) -> PlutusData {
-    PlutusData::Constr(Constr {
-        tag: CBOR_VARIANT_0 + variant,
-        any_constructor: None,
-        fields: if let Some(val) = value {
-            MaybeIndefArray::Indef(vec![val])
-        } else {
-            MaybeIndefArray::Def(vec![])
-        },
-    })
-}
-
-fn decode_enum<'b, C, V: Decode<'b, C>>(
-    d: &mut Decoder<'b>,
-    ctx: &mut C,
-) -> Result<(u64, Option<V>), decode::Error> {
-    let tag = d.tag()?;
-    let variant = tag.as_u64();
-    if variant < CBOR_VARIANT_0 {
-        return Err(decode::Error::message("Invalid plutus struct tag"));
-    };
-    let datum = match d.array()? {
-        Some(0) => None,
-        Some(1) => d.decode_with(ctx)?,
-        Some(_) => return Err(decode::Error::message("Enum has too much data")),
-        None => {
-            if let Type::Break = d.datatype()? {
-                d.skip()?;
-                None
-            } else {
-                let datum = d.decode_with(ctx)?;
-                let Type::Break = d.datatype()? else {
-                    return Err(decode::Error::message("Enum has too much data"));
-                };
-                d.skip()?;
-                Some(datum)
-            }
-        }
-    };
-    Ok((variant - CBOR_VARIANT_0, datum))
-}
-
 #[cfg(test)]
 mod tests {
     use num_bigint::BigUint;
 
-    use super::{deserialize, serialize, IntervalBound, PriceFeed, Validity};
+    use super::{deserialize, serialize, IntervalBound, SyntheticPriceFeed, Validity};
 
     #[test]
     fn should_serialize_infinite_validity() {
         let validity = Validity::default();
-        let round_tripped = deserialize(&serialize(validity)).unwrap();
+        let round_tripped = deserialize(&serialize(&validity)).unwrap();
         assert_eq!(validity, round_tripped);
     }
 
@@ -376,14 +273,14 @@ mod tests {
             lower_bound: IntervalBound::unix_timestamp(1000000, true),
             upper_bound: IntervalBound::unix_timestamp(1005000, true),
         };
-        let round_tripped = deserialize(&serialize(validity)).unwrap();
+        let round_tripped = deserialize(&serialize(&validity)).unwrap();
         assert_eq!(validity, round_tripped);
     }
 
     #[test]
     fn should_serialize_price_feed() {
         // Note: the only thing that doesn't round trip is collateral_names
-        let feed = PriceFeed {
+        let feed = SyntheticPriceFeed {
             collateral_names: None,
             collateral_prices: vec![BigUint::from(1u32), BigUint::from(u128::MAX) * 2u32],
             synthetic: "HIPI".into(),

--- a/src/price_feed.rs
+++ b/src/price_feed.rs
@@ -16,6 +16,7 @@ mod synthetic;
 #[derive(Clone, Debug)]
 pub struct PriceData {
     pub synthetics: Vec<SyntheticPriceData>,
+    pub generics: Vec<GenericPriceFeed>,
 }
 
 #[derive(Decode, Encode, Clone, Debug)]

--- a/src/price_feed/codec.rs
+++ b/src/price_feed/codec.rs
@@ -1,0 +1,178 @@
+use minicbor::{decode, Decoder, Encoder};
+use num_bigint::BigUint;
+use pallas_primitives::{BigInt, Constr, MaybeIndefArray, PlutusData};
+use rust_decimal::prelude::ToPrimitive;
+
+pub trait PlutusCompatible: Sized {
+    fn to_plutus(&self) -> PlutusData;
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error>;
+}
+
+impl<T: PlutusCompatible> PlutusCompatible for Vec<T> {
+    fn to_plutus(&self) -> PlutusData {
+        PlutusData::Array(MaybeIndefArray::Indef(
+            self.iter().map(|i| i.to_plutus()).collect(),
+        ))
+    }
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let PlutusData::Array(array) = data else {
+            return Err(decode::Error::message(
+                "Unexpected plutus type, expected array",
+            ));
+        };
+        array
+            .to_vec()
+            .into_iter()
+            .map(|d| T::from_plutus(d))
+            .collect()
+    }
+}
+
+impl PlutusCompatible for BigUint {
+    fn to_plutus(&self) -> PlutusData {
+        PlutusData::BigInt(match self.to_i64() {
+            Some(val) => BigInt::Int(val.into()),
+            None => BigInt::BigUInt(self.to_bytes_be().into()),
+        })
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let PlutusData::BigInt(value) = data else {
+            return Err(decode::Error::message(
+                "Unexpected plutus type, expected bigint",
+            ));
+        };
+        match value {
+            BigInt::Int(val) => {
+                let raw: i128 = val.into();
+                Ok(BigUint::from(raw as u128))
+            }
+            BigInt::BigUInt(val) => Ok(BigUint::from_bytes_be(&val)),
+            BigInt::BigNInt(_) => Err(decode::Error::message("Unexpected signed integer")),
+        }
+    }
+}
+
+impl PlutusCompatible for u64 {
+    fn to_plutus(&self) -> PlutusData {
+        BigUint::from(*self).to_plutus()
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let bigint = BigUint::from_plutus(data)?;
+        let Some(value) = bigint.to_u64() else {
+            return Err(decode::Error::message("Value out of range"));
+        };
+        Ok(value)
+    }
+}
+
+impl PlutusCompatible for bool {
+    fn to_plutus(&self) -> PlutusData {
+        encode_enum(if *self { 1 } else { 0 }, None)
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        match decode_enum(data)? {
+            (1, None) => Ok(true),
+            (0, None) => Ok(false),
+            _ => Err(decode::Error::message("Unexpected bool value")),
+        }
+    }
+}
+
+impl PlutusCompatible for String {
+    fn to_plutus(&self) -> PlutusData {
+        PlutusData::BoundedBytes(self.as_bytes().to_vec().into())
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let PlutusData::BoundedBytes(bytes) = data else {
+            return Err(decode::Error::message(
+                "Unexpected plutus type, expected bytes",
+            ));
+        };
+        String::from_utf8(bytes.to_vec()).map_err(|e| decode::Error::message(e.to_string()))
+    }
+}
+
+pub fn serialize<T: PlutusCompatible>(data: &T) -> Vec<u8> {
+    let plutus: PlutusData = data.to_plutus();
+    let mut encoder = Encoder::new(vec![]);
+    encoder.encode(&plutus).unwrap(); //infallible
+    encoder.into_writer()
+}
+
+pub fn deserialize<T: PlutusCompatible>(bytes: &[u8]) -> Result<T, decode::Error> {
+    let mut decoder = Decoder::new(bytes);
+    let data: PlutusData = decoder.decode()?;
+    T::from_plutus(data)
+}
+
+const CBOR_VARIANT_0: u64 = 121;
+
+pub fn encode_struct(fields: Vec<PlutusData>) -> PlutusData {
+    PlutusData::Constr(Constr {
+        tag: CBOR_VARIANT_0,
+        any_constructor: None,
+        fields: MaybeIndefArray::Indef(fields),
+    })
+}
+
+pub fn decode_struct<const N: usize>(data: PlutusData) -> Result<[PlutusData; N], decode::Error> {
+    let PlutusData::Constr(Constr { tag, fields, .. }) = data else {
+        return Err(decode::Error::message(
+            "Unexpected plutus type, expected struct",
+        ));
+    };
+    if tag != CBOR_VARIANT_0 {
+        return Err(decode::Error::message(format!(
+            "Invalid plutus struct tag {tag}"
+        )));
+    }
+    fields.to_vec().try_into().map_err(|e: Vec<PlutusData>| {
+        decode::Error::message(format!("Expected {N} field(s), found {}", e.len()))
+    })
+}
+
+pub fn encode_enum(variant: u64, value: Option<PlutusData>) -> PlutusData {
+    PlutusData::Constr(Constr {
+        tag: CBOR_VARIANT_0 + variant,
+        any_constructor: None,
+        fields: if let Some(val) = value {
+            MaybeIndefArray::Indef(vec![val])
+        } else {
+            MaybeIndefArray::Def(vec![])
+        },
+    })
+}
+
+pub fn decode_enum(data: PlutusData) -> Result<(u64, Option<PlutusData>), decode::Error> {
+    let PlutusData::Constr(Constr { tag, fields, .. }) = data else {
+        return Err(decode::Error::message(
+            "Unexpected plutus type, expected struct",
+        ));
+    };
+    let Some(variant) = tag.checked_sub(CBOR_VARIANT_0) else {
+        return Err(decode::Error::message("Invalid plutus struct tag"));
+    };
+    let mut data = fields.to_vec();
+    if data.len() > 1 {
+        return Err(decode::Error::message("Enum has too much data"));
+    }
+
+    Ok((variant, data.pop()))
+}
+
+pub fn cbor_encode_in_list<S: serde::Serializer, T: PlutusCompatible>(
+    feed: &T,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let bytes = {
+        let data = PlutusData::Array(MaybeIndefArray::Indef(vec![feed.to_plutus()]));
+        let mut encoder = Encoder::new(vec![]);
+        encoder.encode(data).expect("encoding is infallible");
+        encoder.into_writer()
+    };
+    serializer.serialize_str(&hex::encode(bytes))
+}

--- a/src/price_feed/generic.rs
+++ b/src/price_feed/generic.rs
@@ -1,0 +1,35 @@
+use num_bigint::BigUint;
+
+use super::{
+    codec::{decode_struct, encode_struct},
+    PlutusCompatible,
+};
+
+#[derive(Clone, Debug)]
+pub struct GenericPriceFeed {
+    pub price: BigUint,
+    pub name: String,
+    pub timestamp: u64,
+}
+
+impl PlutusCompatible for GenericPriceFeed {
+    fn to_plutus(&self) -> pallas_primitives::PlutusData {
+        encode_struct(vec![
+            self.price.to_plutus(),
+            self.name.to_plutus(),
+            self.timestamp.to_plutus(),
+        ])
+    }
+
+    fn from_plutus(data: pallas_primitives::PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_price, encoded_name, encoded_timestamp] = decode_struct(data)?;
+        let price = BigUint::from_plutus(encoded_price)?;
+        let name = String::from_plutus(encoded_name)?;
+        let timestamp = u64::from_plutus(encoded_timestamp)?;
+        Ok(Self {
+            price,
+            name,
+            timestamp,
+        })
+    }
+}

--- a/src/price_feed/generic.rs
+++ b/src/price_feed/generic.rs
@@ -1,3 +1,4 @@
+use minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
 use num_bigint::BigUint;
 
 use super::{
@@ -31,5 +32,21 @@ impl PlutusCompatible for GenericPriceFeed {
             name,
             timestamp,
         })
+    }
+}
+
+impl<C> Encode<C> for GenericPriceFeed {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), encode::Error<W::Error>> {
+        self.to_plutus().encode(e, ctx)
+    }
+}
+
+impl<'b, C> Decode<'b, C> for GenericPriceFeed {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
+        Self::from_plutus(d.decode_with(ctx)?)
     }
 }

--- a/src/price_feed/synthetic.rs
+++ b/src/price_feed/synthetic.rs
@@ -1,0 +1,224 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
+use num_bigint::BigUint;
+use num_rational::BigRational;
+use pallas_primitives::PlutusData;
+
+use super::{
+    codec::{decode_enum, decode_struct, encode_enum, encode_struct},
+    PlutusCompatible,
+};
+
+#[derive(Clone, Debug)]
+pub struct SyntheticPriceData {
+    pub price: BigRational,
+    pub feed: SyntheticPriceFeed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyntheticPriceFeed {
+    pub collateral_names: Option<Vec<String>>,
+    pub collateral_prices: Vec<BigUint>,
+    pub synthetic: String,
+    pub denominator: BigUint,
+    pub validity: Validity,
+}
+
+impl PlutusCompatible for SyntheticPriceFeed {
+    fn to_plutus(&self) -> PlutusData {
+        encode_struct(vec![
+            self.collateral_prices.to_plutus(),
+            self.synthetic.to_plutus(),
+            self.denominator.to_plutus(),
+            self.validity.to_plutus(),
+        ])
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_collateral_prices, encoded_synthetic, encoded_denominator, encoded_validity] =
+            decode_struct(data)?;
+
+        let collateral_prices = Vec::from_plutus(encoded_collateral_prices)?;
+        let synthetic = String::from_plutus(encoded_synthetic)?;
+        let denominator = BigUint::from_plutus(encoded_denominator)?;
+        let validity = Validity::from_plutus(encoded_validity)?;
+        Ok(SyntheticPriceFeed {
+            collateral_names: None,
+            collateral_prices,
+            synthetic,
+            denominator,
+            validity,
+        })
+    }
+}
+
+impl<C> Encode<C> for SyntheticPriceFeed {
+    fn encode<W: encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), encode::Error<W::Error>> {
+        self.to_plutus().encode(e, ctx)
+    }
+}
+
+impl<'b, C> Decode<'b, C> for SyntheticPriceFeed {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, decode::Error> {
+        Self::from_plutus(d.decode_with(ctx)?)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Validity {
+    pub lower_bound: IntervalBound,
+    pub upper_bound: IntervalBound,
+}
+impl Default for Validity {
+    fn default() -> Self {
+        Self {
+            lower_bound: IntervalBound::start_of_time(false),
+            upper_bound: IntervalBound::end_of_time(false),
+        }
+    }
+}
+
+impl PlutusCompatible for Validity {
+    fn to_plutus(&self) -> PlutusData {
+        encode_struct(vec![
+            self.lower_bound.to_plutus(),
+            self.upper_bound.to_plutus(),
+        ])
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        let [encoded_lower_bound, encoded_upper_bound] = decode_struct(data)?;
+        let lower_bound = IntervalBound::from_plutus(encoded_lower_bound)?;
+        let upper_bound = IntervalBound::from_plutus(encoded_upper_bound)?;
+        Ok(Validity {
+            lower_bound,
+            upper_bound,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IntervalBound {
+    pub bound_type: IntervalBoundType,
+    pub is_inclusive: bool,
+}
+impl IntervalBound {
+    pub fn start_of_time(is_inclusive: bool) -> Self {
+        Self {
+            bound_type: IntervalBoundType::NegativeInfinity,
+            is_inclusive,
+        }
+    }
+    pub fn end_of_time(is_inclusive: bool) -> Self {
+        Self {
+            bound_type: IntervalBoundType::PositiveInfinity,
+            is_inclusive,
+        }
+    }
+    pub fn moment(moment: SystemTime, is_inclusive: bool) -> Self {
+        let timestamp = moment
+            .duration_since(UNIX_EPOCH)
+            .expect("it is currently after 1970")
+            .as_millis() as u64;
+        Self::unix_timestamp(timestamp, is_inclusive)
+    }
+    pub fn unix_timestamp(timestamp: u64, is_inclusive: bool) -> Self {
+        Self {
+            bound_type: IntervalBoundType::Finite(timestamp),
+            is_inclusive,
+        }
+    }
+}
+
+impl PlutusCompatible for IntervalBound {
+    fn to_plutus(&self) -> PlutusData {
+        encode_struct(vec![
+            self.bound_type.to_plutus(),
+            self.is_inclusive.to_plutus(),
+        ])
+    }
+
+    fn from_plutus(data: PlutusData) -> Result<Self, minicbor::decode::Error> {
+        let [encoded_bound_type, encoded_is_inclusive] = decode_struct(data)?;
+        let bound_type = IntervalBoundType::from_plutus(encoded_bound_type)?;
+        let is_inclusive = bool::from_plutus(encoded_is_inclusive)?;
+        Ok(IntervalBound {
+            bound_type,
+            is_inclusive,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IntervalBoundType {
+    NegativeInfinity,
+    #[allow(unused)]
+    Finite(u64),
+    PositiveInfinity,
+}
+impl PlutusCompatible for IntervalBoundType {
+    fn to_plutus(&self) -> PlutusData {
+        match self {
+            Self::NegativeInfinity => encode_enum(0, None),
+            Self::Finite(val) => encode_enum(1, Some(val.to_plutus())),
+            Self::PositiveInfinity => encode_enum(2, None),
+        }
+    }
+    fn from_plutus(data: PlutusData) -> Result<Self, decode::Error> {
+        match decode_enum(data)? {
+            (0, None) => Ok(IntervalBoundType::NegativeInfinity),
+            (1, Some(val)) => {
+                let time = u64::from_plutus(val)?;
+                Ok(IntervalBoundType::Finite(time))
+            }
+            (2, None) => Ok(IntervalBoundType::PositiveInfinity),
+            _ => Err(decode::Error::message("Unexpected IntervalBoundType value")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigUint;
+
+    use super::{
+        super::codec::{deserialize, serialize},
+        IntervalBound, SyntheticPriceFeed, Validity,
+    };
+
+    #[test]
+    fn should_serialize_infinite_validity() {
+        let validity = Validity::default();
+        let round_tripped = deserialize(&serialize(&validity)).unwrap();
+        assert_eq!(validity, round_tripped);
+    }
+
+    #[test]
+    fn should_serialize_finite_validity() {
+        let validity = Validity {
+            lower_bound: IntervalBound::unix_timestamp(1000000, true),
+            upper_bound: IntervalBound::unix_timestamp(1005000, true),
+        };
+        let round_tripped = deserialize(&serialize(&validity)).unwrap();
+        assert_eq!(validity, round_tripped);
+    }
+
+    #[test]
+    fn should_serialize_price_feed() {
+        // Note: the only thing that doesn't round trip is collateral_names
+        let feed = SyntheticPriceFeed {
+            collateral_names: None,
+            collateral_prices: vec![BigUint::from(1u32), BigUint::from(u128::MAX) * 2u32],
+            synthetic: "HIPI".into(),
+            denominator: BigUint::from(31337u32),
+            validity: Validity::default(),
+        };
+        let round_tripped = deserialize(&serialize(&feed)).unwrap();
+        assert_eq!(feed, round_tripped);
+    }
+}

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -9,13 +9,14 @@ use tracing::{info, trace, warn};
 use crate::{
     config::OracleConfig,
     network::NodeId,
-    price_feed::{cbor_encode_in_list, Signed, SyntheticPriceFeed},
+    price_feed::{cbor_encode_in_list, GenericPriceFeed, Signed, SyntheticPriceFeed},
     signature_aggregator::Payload,
 };
 
 pub struct Publisher {
     id: NodeId,
-    url: Option<String>,
+    publish_synthetic_url: Option<String>,
+    publish_feed_base_url: Option<String>,
     source: watch::Receiver<Payload>,
     client: Client,
 }
@@ -24,7 +25,8 @@ impl Publisher {
     pub fn new(config: &OracleConfig, source: watch::Receiver<Payload>) -> Result<Self> {
         Ok(Self {
             id: config.id.clone(),
-            url: config.publish_url.clone(),
+            publish_synthetic_url: config.publish_url.clone(),
+            publish_feed_base_url: config.publish_feed_base_url.clone(),
             source,
             client: Client::builder().build()?,
         })
@@ -34,8 +36,9 @@ impl Publisher {
         let mut source = self.source;
         let client = self.client;
         while source.changed().await.is_ok() {
-            let payload = {
+            let (publisher, butane_payload, feeds) = {
                 let latest = source.borrow_and_update();
+
                 let new_entries: Vec<ButaneEntry> = latest
                     .synthetics
                     .iter()
@@ -46,22 +49,52 @@ impl Publisher {
                         payload: e.payload.clone(),
                     })
                     .collect();
-                let payload = serde_json::to_string(&new_entries).expect("infallible");
-                if latest.publisher != self.id {
-                    info!(%latest.publisher, payload, "someone else is publishing a payload");
-                    continue;
-                }
-                payload
-            };
-            if let Some(url) = &self.url {
-                info!(payload, "publishing payload");
+                let butane_payload = serde_json::to_string(&new_entries).expect("infallible");
 
-                match make_request(url, &client, payload).await {
+                let feeds: Vec<FeedEntry> = latest
+                    .generics
+                    .iter()
+                    .filter(|e| e.timestamp == latest.timestamp)
+                    .map(|e| FeedEntry {
+                        feed: e.name.clone(),
+                        payload: e.payload.clone(),
+                    })
+                    .collect();
+
+                // todo
+                (latest.publisher.clone(), butane_payload, feeds)
+            };
+
+            if publisher != self.id {
+                let feed_payloads = serde_json::to_string(&feeds).expect("infallible");
+                info!(%publisher, butane_payload, feed_payloads, "someone else is publishing a payload");
+                continue;
+            }
+
+            if let Some(url) = &self.publish_synthetic_url {
+                info!(butane_payload, "publishing payload");
+
+                match make_request(url, &client, butane_payload).await {
                     Ok(res) => trace!("Payload published! {}", res),
                     Err(err) => warn!("Could not publish payload: {}", err),
                 }
             } else {
-                info!(payload, "final payload (not publishing)");
+                info!(butane_payload, "final payload (not publishing)");
+            }
+
+            for feed in feeds {
+                let name = feed.feed.clone();
+                let feed_payload = serde_json::to_string(&feed).expect("infallible");
+                if let Some(url) = &self.publish_feed_base_url {
+                    let full_url = format!("{url}/{}", urlencoding::encode(&name));
+                    info!(feed_payload, name, "publishing feed payload");
+                    match make_request(&full_url, &client, feed_payload).await {
+                        Ok(res) => trace!(name, "Payload published! {}", res),
+                        Err(err) => warn!(name, "Could not publish payload: {}", err),
+                    }
+                } else {
+                    info!(feed_payload, name, "feed payload (not publishing)")
+                }
             }
         }
     }
@@ -73,6 +106,13 @@ struct ButaneEntry {
     pub price: f64,
     #[serde(serialize_with = "cbor_encode_in_list")]
     pub payload: Signed<SyntheticPriceFeed>,
+}
+
+#[derive(Serialize)]
+struct FeedEntry {
+    pub feed: String,
+    #[serde(serialize_with = "cbor_encode_in_list")]
+    pub payload: Signed<GenericPriceFeed>,
 }
 
 async fn make_request(url: &str, client: &Client, payload: String) -> Result<String> {

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -93,12 +93,16 @@ impl SignatureAggregator {
             mpsc::Sender<(NodeId, SignedEntries)>,
         ) -> Result<SignatureAggregatorImplementation>,
     {
-        let feeds = config
-            .synthetics
-            .iter()
-            .map(|s| s.name.clone())
-            .chain(config.feeds.all_feeds().iter().map(|f| f.name()))
-            .collect();
+        let mut feeds = vec![];
+        for synthetic in &config.synthetics {
+            feeds.push(synthetic.name.clone());
+        }
+        for currency in &config.feeds.currencies {
+            feeds.push(format!("USD/{currency}#RAW"));
+            feeds.push(format!("{currency}/USD#RAW"));
+            feeds.push(format!("USD/{currency}#GEMA"));
+            feeds.push(format!("{currency}/USD#GEMA"));
+        }
         let (signed_entries_sink, signed_entries_source) = mpsc::channel(10);
         let (payload_sink, mut payload_source) = watch::channel(Payload {
             publisher: config.id.clone(),

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -27,7 +27,7 @@ use crate::{
     config::OracleConfig,
     network::{Network, NodeId},
     price_feed::{
-        cbor_encode_in_list, IntervalBoundType, PriceData, Signed, SignedEntries, SyntheticEntry,
+        cbor_encode_in_list, GenericPriceFeed, IntervalBoundType, PriceData, Signed, SignedEntries,
         SyntheticPriceFeed,
     },
     raft::{RaftClient, RaftLeader},
@@ -36,7 +36,7 @@ use crate::{
 pub struct SignatureAggregator {
     id: NodeId,
     implementation: SignatureAggregatorImplementation,
-    synthetics: Vec<String>,
+    feeds: Vec<String>,
     raft_client: RaftClient,
     signed_entries_source: mpsc::Receiver<(NodeId, SignedEntries)>,
     payload_sink: watch::Sender<Payload>,
@@ -93,12 +93,18 @@ impl SignatureAggregator {
             mpsc::Sender<(NodeId, SignedEntries)>,
         ) -> Result<SignatureAggregatorImplementation>,
     {
-        let synthetics = config.synthetics.iter().map(|s| s.name.clone()).collect();
+        let feeds = config
+            .synthetics
+            .iter()
+            .map(|s| s.name.clone())
+            .chain(config.feeds.all_feeds().iter().map(|f| f.name()))
+            .collect();
         let (signed_entries_sink, signed_entries_source) = mpsc::channel(10);
         let (payload_sink, mut payload_source) = watch::channel(Payload {
             publisher: config.id.clone(),
             timestamp: SystemTime::UNIX_EPOCH,
             synthetics: vec![],
+            generics: vec![],
         });
         payload_source.mark_unchanged();
 
@@ -106,7 +112,7 @@ impl SignatureAggregator {
         let aggregator = SignatureAggregator {
             id: config.id.clone(),
             implementation,
-            synthetics,
+            feeds,
             raft_client,
             signed_entries_source,
             payload_sink,
@@ -123,13 +129,13 @@ impl SignatureAggregator {
             }
         };
 
-        let payload_ages: DashMap<String, (SystemTime, SystemTime)> = self
-            .synthetics
+        let payload_ages: DashMap<String, (SystemTime, Option<SystemTime>)> = self
+            .feeds
             .iter()
-            .map(|synthetic| {
+            .map(|feed| {
                 let now = SystemTime::now();
-                let later = now + Duration::from_secs(60);
-                (synthetic.clone(), (now, later))
+                let later = Some(now + Duration::from_secs(60));
+                (feed.clone(), (now, later))
             })
             .collect();
         let payload_ages = Arc::new(payload_ages);
@@ -142,7 +148,7 @@ impl SignatureAggregator {
                     let (last_updated, valid_until) = *entry.value();
                     drop(entry);
 
-                    let is_valid: u64 = if SystemTime::now() < valid_until {
+                    let is_valid: u64 = if valid_until.is_none_or(|t| SystemTime::now() < t) {
                         1
                     } else {
                         0
@@ -163,63 +169,71 @@ impl SignatureAggregator {
         };
 
         let id = self.id;
-        let synthetics = self.synthetics;
+        let feeds = self.feeds;
         let raft_client = self.raft_client;
         let mut payload_source = self.signed_entries_source;
         let publish_task = async move {
-            // map of synthetic name to most recent payload produced for that entry
-            let mut latest_entries: BTreeMap<String, SyntheticPayloadEntry> = BTreeMap::new();
+            // map of feed to most recent entry produced for that feed
+            let mut latest_entries: BTreeMap<String, PayloadEntry> = BTreeMap::new();
 
-            // map of synthetic name to number of times it's failed in a row
-            let mut synthetic_failures: BTreeMap<String, usize> =
-                synthetics.iter().map(|s| (s.clone(), 0)).collect();
+            // map of feed name to number of times it's failed in a row
+            let mut all_failures: BTreeMap<String, usize> =
+                feeds.iter().map(|s| (s.clone(), 0)).collect();
 
             while let Some((publisher, payload)) = payload_source.recv().await {
                 let span = info_span!("publish_entries");
                 let mut updated = BTreeSet::new();
                 // update the payload age monitor now that we have a new payload
-                for entry in &payload.synthetics {
-                    let synthetic = entry.feed.data.synthetic.clone();
-                    let last_updated = entry.timestamp.unwrap_or(payload.timestamp);
+                let synthetics = payload.synthetics.into_iter().map(|s| {
+                    PayloadEntry::Synthetic(SyntheticPayloadEntry {
+                        timestamp: s.timestamp.unwrap_or(payload.timestamp),
+                        synthetic: s.feed.data.synthetic.clone(),
+                        price: s.price,
+                        payload: s.feed,
+                    })
+                });
+                let generics = payload.generics.into_iter().map(|i| {
+                    PayloadEntry::Generic(GenericPayloadEntry {
+                        timestamp: i.timestamp,
+                        name: i.feed.data.name.clone(),
+                        payload: i.feed,
+                    })
+                });
+                for entry in synthetics.chain(generics) {
+                    let feed = entry.feed();
                     if latest_entries
-                        .get(&synthetic)
-                        .is_some_and(|e| e.timestamp >= last_updated)
+                        .get(&feed)
+                        .is_some_and(|e| e.timestamp() >= entry.timestamp())
                     {
                         // This isn't actually a NEW payload...
                         continue;
                     }
-                    updated.insert(synthetic.clone());
-                    let price_feed_size = entry.feed.cbor_len(&mut ()) as u64;
-                    span.in_scope(|| {
-                        debug!(
-                            histogram.price_feed_size = price_feed_size,
-                            synthetic, "price feed size metrics"
-                        );
-                    });
-                    latest_entries.insert(
-                        synthetic.clone(),
-                        SyntheticPayloadEntry {
-                            timestamp: last_updated,
-                            synthetic: synthetic.clone(),
-                            price: entry.price,
-                            payload: entry.feed.clone(),
-                        },
-                    );
-                    let valid_until = find_end_of_entry_validity(entry);
-                    payload_ages.insert(synthetic, (last_updated, valid_until));
+                    updated.insert(feed.clone());
+                    if let PayloadEntry::Synthetic(synth) = &entry {
+                        let price_feed_size = synth.payload.cbor_len(&mut ()) as u64;
+                        span.in_scope(|| {
+                            debug!(
+                                histogram.price_feed_size = price_feed_size,
+                                synthetic = synth.synthetic,
+                                "price feed size metrics"
+                            );
+                        });
+                    }
+                    payload_ages.insert(feed.clone(), (entry.timestamp(), entry.valid_until()));
+                    latest_entries.insert(feed, entry);
                 }
 
                 if publisher == id {
                     // count the number of times we failed to publish some synthetic
                     let mut something_failed_too_often = false;
-                    for (synthetic, failures) in synthetic_failures.iter_mut() {
-                        if updated.contains(synthetic) {
+                    for (feed, failures) in all_failures.iter_mut() {
+                        if updated.contains(feed) {
                             *failures = 0;
                         } else {
                             *failures += 1;
                             span.in_scope(|| {
                                 warn!(
-                                    synthetic,
+                                    feed,
                                     failures, "Could not publish new price feed for synthetic"
                                 );
                             });
@@ -236,17 +250,23 @@ impl SignatureAggregator {
                         raft_client.abdicate();
                     }
                 } else {
-                    for failures in synthetic_failures.values_mut() {
+                    for failures in all_failures.values_mut() {
                         *failures = 0;
                     }
                 }
 
-                let entries = latest_entries.values().cloned().collect();
-                let payload = Payload {
+                let mut payload = Payload {
                     publisher,
                     timestamp: payload.timestamp,
-                    synthetics: entries,
+                    synthetics: vec![],
+                    generics: vec![],
                 };
+                for entry in latest_entries.values().cloned() {
+                    match entry {
+                        PayloadEntry::Synthetic(entry) => payload.synthetics.push(entry),
+                        PayloadEntry::Generic(entry) => payload.generics.push(entry),
+                    }
+                }
                 self.payload_sink.send_replace(payload);
             }
         };
@@ -259,8 +279,36 @@ impl SignatureAggregator {
     }
 }
 
-fn find_end_of_entry_validity(entry: &SyntheticEntry) -> SystemTime {
-    let upper_bound = entry.feed.data.validity.upper_bound;
+#[derive(Clone)]
+enum PayloadEntry {
+    Synthetic(SyntheticPayloadEntry),
+    Generic(GenericPayloadEntry),
+}
+impl PayloadEntry {
+    fn feed(&self) -> String {
+        match self {
+            Self::Synthetic(entry) => entry.synthetic.clone(),
+            Self::Generic(entry) => entry.name.clone(),
+        }
+    }
+
+    fn timestamp(&self) -> SystemTime {
+        match self {
+            Self::Synthetic(entry) => entry.timestamp,
+            Self::Generic(entry) => entry.timestamp,
+        }
+    }
+
+    fn valid_until(&self) -> Option<SystemTime> {
+        match self {
+            Self::Synthetic(entry) => Some(find_end_of_entry_validity(entry)),
+            Self::Generic(_) => None,
+        }
+    }
+}
+
+fn find_end_of_entry_validity(entry: &SyntheticPayloadEntry) -> SystemTime {
+    let upper_bound = entry.payload.data.validity.upper_bound;
     match upper_bound.bound_type {
         IntervalBoundType::NegativeInfinity => SystemTime::UNIX_EPOCH,
         IntervalBoundType::PositiveInfinity => SystemTime::now() + Duration::from_secs(60 * 525600),
@@ -280,8 +328,17 @@ pub struct SyntheticPayloadEntry {
 }
 
 #[derive(Serialize, Clone)]
+pub struct GenericPayloadEntry {
+    pub timestamp: SystemTime,
+    pub name: String,
+    #[serde(serialize_with = "cbor_encode_in_list")]
+    pub payload: Signed<GenericPriceFeed>,
+}
+
+#[derive(Serialize, Clone)]
 pub struct Payload {
     pub publisher: NodeId,
     pub timestamp: SystemTime,
+    pub generics: Vec<GenericPayloadEntry>,
     pub synthetics: Vec<SyntheticPayloadEntry>,
 }

--- a/src/signature_aggregator/consensus_aggregator.rs
+++ b/src/signature_aggregator/consensus_aggregator.rs
@@ -14,7 +14,7 @@ use crate::{
     config::OracleConfig,
     keys,
     network::{NetworkChannel, NetworkReceiver, NodeId},
-    price_feed::{PriceFeedEntry, SignedEntries},
+    price_feed::{PriceData, SignedEntries},
     raft::RaftLeader,
 };
 
@@ -30,7 +30,7 @@ impl ConsensusSignatureAggregator {
     pub fn new(
         config: &OracleConfig,
         channel: NetworkChannel<SignerMessage>,
-        price_source: watch::Receiver<Vec<PriceFeedEntry>>,
+        price_source: watch::Receiver<PriceData>,
         leader_source: watch::Receiver<RaftLeader>,
         signed_entries_sink: mpsc::Sender<(NodeId, SignedEntries)>,
     ) -> Result<Self> {

--- a/src/signature_aggregator/price_comparator.rs
+++ b/src/signature_aggregator/price_comparator.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::price_feed::{IntervalBound, IntervalBoundType, PriceFeed, Validity};
+use crate::price_feed::{IntervalBound, IntervalBoundType, SyntheticPriceFeed, Validity};
 
 #[derive(Debug)]
 pub enum ComparisonResult {
@@ -9,8 +9,8 @@ pub enum ComparisonResult {
 }
 
 pub fn choose_feeds_to_sign<'a>(
-    leader_feed: &'a [PriceFeed],
-    my_feed: &'a [PriceFeed],
+    leader_feed: &'a [SyntheticPriceFeed],
+    my_feed: &'a [SyntheticPriceFeed],
 ) -> Vec<(&'a str, ComparisonResult)> {
     let leader_values: BTreeMap<_, _> = leader_feed
         .iter()
@@ -45,7 +45,7 @@ pub fn choose_feeds_to_sign<'a>(
     results
 }
 
-fn should_sign(leader_feed: &PriceFeed, my_feed: &PriceFeed) -> ComparisonResult {
+fn should_sign(leader_feed: &SyntheticPriceFeed, my_feed: &SyntheticPriceFeed) -> ComparisonResult {
     if leader_feed.synthetic != my_feed.synthetic {
         return ComparisonResult::DoNotSign(format!(
             "mismatched synthetics: leader has {}, we have {}",
@@ -119,7 +119,7 @@ mod tests {
 
     use super::choose_feeds_to_sign;
     use crate::{
-        price_feed::{IntervalBound, PriceFeed, Validity},
+        price_feed::{IntervalBound, SyntheticPriceFeed, Validity},
         signature_aggregator::price_comparator::ComparisonResult,
     };
 
@@ -128,8 +128,8 @@ mod tests {
         collateral_names: &[&str],
         collateral_prices: &[u64],
         denominator: u64,
-    ) -> PriceFeed {
-        PriceFeed {
+    ) -> SyntheticPriceFeed {
+        SyntheticPriceFeed {
             collateral_names: Some(collateral_names.iter().map(|&s| s.to_string()).collect()),
             collateral_prices: collateral_prices
                 .iter()

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -932,6 +932,10 @@ impl Signer {
             self.validate_feed_signature(&entry.feed)
                 .context("tried to publish feed with invalid signature")?;
         }
+        for entry in &payload.generics {
+            self.validate_feed_signature(&entry.feed)
+                .context("tried to publish feed with invalid signature")?;
+        }
         self.signed_entries_sink
             .send((publisher, payload.clone()))
             .await

--- a/src/signature_aggregator/signer.rs
+++ b/src/signature_aggregator/signer.rs
@@ -804,6 +804,7 @@ impl Signer {
         let payload = SignedEntries {
             timestamp: now,
             synthetics: payload_entries.into_values().collect(),
+            generics: vec![], // TODO
         };
 
         self.publish(self.id.clone(), payload.clone()).await?;

--- a/src/signature_aggregator/single_aggregator.rs
+++ b/src/signature_aggregator/single_aggregator.rs
@@ -66,6 +66,7 @@ impl SingleSignatureAggregator {
             let payload = SignedEntries {
                 timestamp: SystemTime::now(),
                 synthetics: payload_entries,
+                generics: vec![], // TODO
             };
 
             if let Err(error) = self


### PR DESCRIPTION
In addition to posting a list of synthetic feeds to Butane, post individual "generic" feeds for the price of ADA in USD. New feeds are
 - `USD/ADA#RAW`
 - `ADA/USD#RAW`
 - `USD/ADA#GEMA`
 - `ADA/USD#GEMA`

These feeds contain an integer price (the actual price * 10^7), the name of the feed, and the timestamp that an entry was produced. They do not contain a valid range, and never "expire".