### PR TITLE
feat: read collateral for synthetics from onchain

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -22,98 +22,94 @@ synthetics:
     backing_currencies:
       - USD
     collateral:
-      - ADA
-      - BTN
-      - SNEK
-      - MIN
-      - LENFI
-      - ENCS
+      list:
+        - ADA
+        - BTN
+        - SNEK
+        - MIN
+        - LENFI
+        - ENCS
   - name: USDs
     digits: 6
     backing_currencies:
       - USD
     collateral:
-      - ADA
-      - USDb
-      - BTN
-      - DJED
-      - myUSD
-      - iUSD
+      list:
+        - ADA
+        - USDb
+        - BTN
+        - DJED
+        - myUSD
+        - iUSD
   - name: EURb
     digits: 6
     backing_currencies:
       - EUR
     collateral:
-      - ADA
-      - USDb
-      - USDs
-      - BTN
+      list:
+        - ADA
+        - USDb
+        - USDs
+        - BTN
   - name: JPYb
     digits: 6
     backing_currencies:
       - JPY
     collateral:
-      - ADA
-      - USDb
-      - USDs
-      - BTN
+      list:
+        - ADA
+        - USDb
+        - USDs
+        - BTN
   - name: BTCb
     digits: 8
     backing_currencies:
       - BTC
     collateral:
-      - ADA
-      - USDb
-      - USDs
-      - BTN
-      - SNEK
-      - MIN
-      - LENFI
-      - ENCS
+      list:
+        - ADA
+        - USDb
+        - USDs
+        - BTN
+        - SNEK
+        - MIN
+        - LENFI
+        - ENCS
   - name: POLb
     digits: 6
     backing_currencies:
       - POL
     collateral:
-      - ADA
-      - BTCb
-      - BTN
-      - SNEK
-      - MIN
-      - LENFI
-      - ENCS
+      list:
+        - ADA
+        - BTCb
+        - BTN
+        - SNEK
+        - MIN
+        - LENFI
+        - ENCS
   - name: SOLp
     digits: 9
     backing_currencies:
       - SOL
     invert: true
     collateral:
-      - ADA
-      - USDb
-      - USDs
-      - BTN
-      - SNEK
-      - MIN
-      - LENFI
-      - ENCS
+      list:
+        - ADA
+        - USDb
+        - USDs
+        - BTN
+        - SNEK
+        - MIN
+        - LENFI
+        - ENCS
   - name: MIDAS
     digits: 9
     backing_currencies:
       - PAXG
       - XAUt
     collateral:
-      - ADA
-      - BTN
-      - SNEK
-      - MIN
-      - FLDT
-      - IAG
-      - SHEN
-      - LENFI
-      - SUNDAE
-      - ENCS
-      - LQ
-      - iETH
+      nft: 00000000000410c2d9e01e8ec78ab1dc6bbc383fae76cbe2689beb02.705f4d49444153
 currencies:
   - name: ADA
     digits: 6
@@ -293,9 +289,12 @@ okx:
     - token: XAUt
       unit: USDT
       index: XAUT-USDT
+kupo:
+  kupo_address: http://kupo:1442
+  retries: 3
+  timeout_ms: 5000
 sundaeswap:
   use_api: false
-  kupo_address: http://kupo:1442
   policy_id: e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b
   pools:
     - token: BTN
@@ -351,10 +350,7 @@ sundaeswap:
       credential: e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b/*
       asset_id: e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b.000de1402f36866691fa75a9aab66dec99f7cc2d297ca09e34d9ce68cde04773
   max_concurrency: 3
-  retries: 3
-  timeout_ms: 5000
 minswap:
-  kupo_address: http://kupo:1442
   pools:
     # V1 pools
     - token: BTN
@@ -475,10 +471,7 @@ minswap:
       credential: ea07b733d932129c378af627436e7cbc2ef0bf96e0036bb51b3bde6b/*
       asset_id: f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c.f734af78799c4e857bfd37e8f919678020c0bb3f2aae9328bdb7c557a939a926
   max_concurrency: 3
-  retries: 3
-  timeout_ms: 5000
 spectrum:
-  kupo_address: http://kupo:1442
   pools:
     - token: BTN
       unit: ADA
@@ -505,8 +498,6 @@ spectrum:
       credential: 6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69/*
       asset_id: f8fd67ee46f66da669f68dc941090eb753687636b47fc6fd7f5e6254.534e454b5f4144415f4e4654
   max_concurrency: 3
-  retries: 3
-  timeout_ms: 5000
 fxratesapi:
   cron: "0 4 * ? * ? *" # Run four minutes past the hour, every hour
   currencies:

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -290,7 +290,6 @@ okx:
       unit: USDT
       index: XAUT-USDT
 kupo:
-  kupo_address: http://kupo:1442
   retries: 3
   timeout_ms: 5000
 sundaeswap:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,8 @@ keygen:
 frost_address: addr11111111111
   # This is the address of your current FROST public key. The key generation process will print it.
   # Every node must agree on this.
+kupo:
+  kupo_address: http://localhost:1442
 peers:
   - address: 127.0.0.1:8001
     label: Descriptive label

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,6 +3,8 @@ members = ["cargo:."]
 
 # Config for 'dist'
 [dist]
+# Allow dirty because we are using different ubuntu versions than the script generates
+allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.28.0"
 # CI backends to support

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,7 +518,7 @@ mod tests {
         let test_keys_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/keys");
         let sample_config_file = concat!(env!("CARGO_MANIFEST_DIR"), "/config.example.yaml");
         temp_env::with_var("KEYS_DIRECTORY", Some(test_keys_dir), || {
-            load_config(&[sample_config_file]).unwrap();
+            load_config([sample_config_file]).unwrap();
         });
         Ok(())
     }

--- a/src/price_aggregator/conversions.rs
+++ b/src/price_aggregator/conversions.rs
@@ -181,7 +181,7 @@ mod tests {
     use rust_decimal::Decimal;
 
     use crate::{
-        config::SyntheticConfig,
+        config::{CollateralConfig, SyntheticConfig},
         price_aggregator::{TokenPrice, TokenPriceSource},
         sources::source::PriceInfo,
     };
@@ -224,21 +224,21 @@ mod tests {
                 backing_currencies: vec!["USD".into()],
                 invert: false,
                 digits: 6,
-                collateral: vec![],
+                collateral: CollateralConfig::List(vec![]),
             },
             SyntheticConfig {
                 name: "BTCb".into(),
                 backing_currencies: vec!["BTC".into()],
                 invert: false,
                 digits: 8,
-                collateral: vec![],
+                collateral: CollateralConfig::List(vec![]),
             },
             SyntheticConfig {
                 name: "SOLp".into(),
                 backing_currencies: vec!["SOL".into()],
                 invert: true,
                 digits: 9,
-                collateral: vec![],
+                collateral: CollateralConfig::List(vec![]),
             },
             SyntheticConfig {
                 name: "MULTI".into(),
@@ -247,7 +247,7 @@ mod tests {
                     .collect(),
                 invert: false,
                 digits: 6,
-                collateral: vec![],
+                collateral: CollateralConfig::List(vec![]),
             },
         ]
     }

--- a/src/price_aggregator/synth_config_source.rs
+++ b/src/price_aggregator/synth_config_source.rs
@@ -1,0 +1,187 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use crate::config::{CollateralConfig, OracleConfig};
+use anyhow::{bail, Result};
+use futures::{stream::FuturesUnordered, StreamExt};
+use kupon::MatchOptions;
+use pallas_primitives::{Constr, PlutusData};
+use tracing::warn;
+
+pub struct SyntheticConfigSource {
+    asset_names: HashMap<String, String>,
+    nfts: HashMap<String, String>,
+    collateral: HashMap<String, Vec<String>>,
+    client: kupon::Client,
+    next_refresh: Instant,
+}
+
+impl SyntheticConfigSource {
+    pub fn new(config: &OracleConfig) -> Result<Self> {
+        let mut asset_ids = HashMap::new();
+        let mut asset_names = HashMap::new();
+        for (name, asset_id) in config
+            .currencies
+            .iter()
+            .filter_map(|c| Some((&c.name, c.asset_id.as_ref()?)))
+        {
+            asset_ids.insert(name.clone(), asset_id.clone());
+            asset_names.insert(asset_id.clone(), name.clone());
+        }
+
+        let mut nfts = HashMap::new();
+        let mut collateral = HashMap::new();
+        for synth in &config.synthetics {
+            match &synth.collateral {
+                CollateralConfig::List(tokens) => {
+                    let mut tokens = tokens.clone();
+                    tokens.sort_by_cached_key(|c| asset_ids.get(c));
+                    collateral.insert(synth.name.clone(), tokens);
+                }
+                CollateralConfig::Nft(nft) => {
+                    nfts.insert(synth.name.clone(), nft.clone());
+                }
+            }
+        }
+        let client = config.kupo.new_client()?;
+        let next_refresh = Instant::now();
+        Ok(Self {
+            asset_names,
+            nfts,
+            collateral,
+            client,
+            next_refresh,
+        })
+    }
+
+    pub async fn refresh(&mut self) {
+        let now = Instant::now();
+        if now < self.next_refresh {
+            return;
+        }
+
+        let mut futures = FuturesUnordered::new();
+        for (synthetic, nft) in &self.nfts {
+            let asset_names = &self.asset_names;
+            let client = &self.client;
+            futures.push(async move {
+                let query = MatchOptions::default().asset_id(nft).only_unspent();
+                let mut matches = client.matches(&query).await?;
+                if matches.is_empty() {
+                    bail!("No UTxO found for NFT {nft}");
+                }
+                if matches.len() > 1 {
+                    bail!("Found {} UTxOs for NFT {nft}, expected 1", matches.len());
+                }
+                let Some(datum_hash) = matches.pop().unwrap().datum else {
+                    bail!("No datum associated with NFT {nft}");
+                };
+                let Some(raw_datum) = client.datum(&datum_hash.hash).await? else {
+                    bail!("Datum not found for NFT {nft}");
+                };
+                let datum_bytes = hex::decode(raw_datum)?;
+                let datum: PlutusData = minicbor::Decoder::new(&datum_bytes).decode()?;
+
+                let collateral_assets = match extract_collateral_assets(datum) {
+                    Ok(assets) => assets,
+                    Err(error) => bail!("Could not parse datum for NFT {nft}: {error}"),
+                };
+
+                let mut collateral = vec![];
+                for AssetClass {
+                    policy_id,
+                    asset_name,
+                } in collateral_assets
+                {
+                    if policy_id.is_empty() && asset_name.is_empty() {
+                        collateral.push("ADA".to_string());
+                        continue;
+                    }
+                    let asset_id = format!("{policy_id}.{asset_name}");
+                    let Some(name) = asset_names.get(&asset_id) else {
+                        bail!("Unrecognized asset id {asset_id}");
+                    };
+                    collateral.push(name.clone());
+                }
+
+                Ok((synthetic, collateral))
+            });
+        }
+
+        while let Some(result) = futures.next().await {
+            match result {
+                Ok((synthetic, collateral)) => {
+                    self.collateral.insert(synthetic.clone(), collateral);
+                }
+                Err(error) => {
+                    warn!("{}", error);
+                }
+            }
+        }
+
+        self.next_refresh = now + Duration::from_secs(30);
+    }
+
+    pub fn synthetic_collateral(&self, name: &str) -> Option<Vec<String>> {
+        Some(self.collateral.get(name)?.clone())
+    }
+}
+
+// input is a MonoDatum from the butane Aiken definition
+fn extract_collateral_assets(datum: PlutusData) -> Result<Vec<AssetClass>> {
+    // extract the ParamsWrapper
+    let [wrapper] = decode_struct(datum, 0)?;
+    // extract the LiveParams
+    let [params] = decode_struct(wrapper, 0)?;
+    // extract the collateral assets from the LiveParams
+    let [collateral_assets] = decode_struct(params, 0)?;
+
+    let PlutusData::Array(collateral_assets) = collateral_assets else {
+        bail!("datum has invalid collateral assets");
+    };
+
+    let mut assets = vec![];
+    for (index, asset) in collateral_assets.to_vec().into_iter().enumerate() {
+        let [policy_id, asset_name] = decode_struct(asset, 0)?;
+        let PlutusData::BoundedBytes(policy_id) = policy_id else {
+            bail!("asset {index} has invalid policy id");
+        };
+        let PlutusData::BoundedBytes(asset_name) = asset_name else {
+            bail!("asset {index} has invalid asset name");
+        };
+        assets.push(AssetClass {
+            policy_id: policy_id.into(),
+            asset_name: asset_name.into(),
+        });
+    }
+    Ok(assets)
+}
+
+fn decode_struct<const N: usize>(datum: PlutusData, variant: u64) -> Result<[PlutusData; N]> {
+    let PlutusData::Constr(Constr { tag, fields, .. }) = datum else {
+        bail!("datum is not a struct");
+    };
+    if tag != variant + 121 {
+        bail!(
+            "datum has unexpected variant (expected {}, got {})",
+            variant + 121,
+            tag
+        );
+    }
+    fields
+        .to_vec()
+        .into_iter()
+        .take(N)
+        .collect::<Vec<_>>()
+        .try_into()
+        .map_err(|e: Vec<_>| {
+            anyhow::anyhow!("too few elements (expected at least {N}, got {})", e.len())
+        })
+}
+
+struct AssetClass {
+    policy_id: String,
+    asset_name: String,
+}

--- a/src/sources/minswap.rs
+++ b/src/sources/minswap.rs
@@ -37,10 +37,9 @@ impl Source for MinswapSource {
 impl MinswapSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let minswap_config = &config.minswap;
-        let client = kupon::Builder::with_endpoint(&minswap_config.kupo_address)
-            .with_retries(minswap_config.retries)
-            .with_timeout(Duration::from_millis(minswap_config.timeout_ms))
-            .build()?;
+        let client = config
+            .kupo_with_overrides(&minswap_config.kupo)
+            .new_client()?;
         Ok(Self {
             client: Arc::new(client),
             max_concurrency: minswap_config.max_concurrency,

--- a/src/sources/spectrum.rs
+++ b/src/sources/spectrum.rs
@@ -37,10 +37,9 @@ impl Source for SpectrumSource {
 impl SpectrumSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let spectrum_config = &config.spectrum;
-        let client = kupon::Builder::with_endpoint(&spectrum_config.kupo_address)
-            .with_retries(spectrum_config.retries)
-            .with_timeout(Duration::from_millis(spectrum_config.timeout_ms))
-            .build()?;
+        let client = config
+            .kupo_with_overrides(&spectrum_config.kupo)
+            .new_client()?;
         Ok(Self {
             client: Arc::new(client),
             max_concurrency: spectrum_config.max_concurrency,

--- a/src/sources/sundaeswap_kupo.rs
+++ b/src/sources/sundaeswap_kupo.rs
@@ -42,10 +42,9 @@ impl Source for SundaeSwapKupoSource {
 impl SundaeSwapKupoSource {
     pub fn new(config: &OracleConfig) -> Result<Self> {
         let sundae_config = &config.sundaeswap;
-        let client = kupon::Builder::with_endpoint(&sundae_config.kupo_address)
-            .with_retries(sundae_config.retries)
-            .with_timeout(Duration::from_millis(sundae_config.timeout_ms))
-            .build()?;
+        let client = config
+            .kupo_with_overrides(&sundae_config.kupo)
+            .new_client()?;
         Ok(Self {
             client: Arc::new(client),
             max_concurrency: sundae_config.max_concurrency,


### PR DESCRIPTION
For each synthetic, read its list of acceptable collateral from on-chain.

With this change, Butane can unilaterally
 - add new collateral to a synthetic, as long as we already track that collateral's price
 - remove collateral from a synthetic
 - remove a synthetic

We still need to deploy a new oracle version with config updates whenever we 
 - add a new synthetic
 - track the price for a new form of collateral
 - update the sources/pools used to query collateral prices

Warning: this is a breaking configuration change. There is a new top-level `kupo` object which must be populated:
```yaml
kupo:
  kupo_address: <blah>
```
