### PR TITLE
Stop using volume as a proxy for reliability

### DIFF
--- a/src/sources/binance.rs
+++ b/src/sources/binance.rs
@@ -85,13 +85,12 @@ impl BinanceSource {
         };
         let token = &stream.token;
         let value = Decimal::from_str(&message.data.price)?;
-        let volume = Decimal::from_str(&message.data.volume_base)?;
 
         sink.send(PriceInfo {
             token: token.to_string(),
             unit: stream.unit.to_string(),
             value,
-            reliability: volume,
+            reliability: Decimal::ONE,
         })?;
 
         Ok(())
@@ -107,6 +106,4 @@ struct BinanceMarkPriceMessage {
 struct BinanceMarkPriceMessageData {
     #[serde(rename(deserialize = "c"))]
     price: String,
-    #[serde(rename(deserialize = "v"))]
-    volume_base: String,
 }

--- a/src/sources/bybit.rs
+++ b/src/sources/bybit.rs
@@ -21,7 +21,6 @@ struct ByBitPriceInfo {
     token: String,
     unit: String,
     last_value: Option<Decimal>,
-    last_volume: Option<Decimal>,
 }
 impl ByBitPriceInfo {
     fn new(token: &str, unit: &str) -> Self {
@@ -29,7 +28,6 @@ impl ByBitPriceInfo {
             token: token.to_string(),
             unit: unit.to_string(),
             last_value: None,
-            last_volume: None,
         }
     }
 }
@@ -131,20 +129,11 @@ impl ByBitSource {
                 };
                 info.last_value = Some(value);
 
-                let Some(volume) = data
-                    .volume_24h
-                    .and_then(|x| Decimal::from_str(&x).ok())
-                    .or(info.last_volume)
-                else {
-                    continue;
-                };
-                info.last_volume = Some(volume);
-
                 let price_info = PriceInfo {
                     token: info.token.clone(),
                     unit: info.unit.clone(),
                     value,
-                    reliability: volume,
+                    reliability: Decimal::ONE,
                 };
                 sink.send(price_info)?;
             }
@@ -185,5 +174,4 @@ enum ByBitResponse {
 struct TickerSnapshotData {
     symbol: String,
     mark_price: Option<String>,
-    volume_24h: Option<String>,
 }

--- a/src/sources/coinbase.rs
+++ b/src/sources/coinbase.rs
@@ -83,24 +83,18 @@ impl CoinbaseSource {
 
     fn parse_message(&self, message: Message) -> Result<PriceInfo> {
         let response: CoinbaseResponse = message.clone().try_into()?;
-        let CoinbaseResponse::Ticker {
-            product_id,
-            price,
-            volume_24h,
-        } = response
-        else {
+        let CoinbaseResponse::Ticker { product_id, price } = response else {
             return Err(anyhow!("Unexpected response from coinbase: {:?}", response));
         };
         let Some(product) = self.products.get(&product_id) else {
             return Err(anyhow!("Unrecognized price to match: {}", product_id));
         };
         let value = Decimal::from_str(&price)?;
-        let volume = Decimal::from_str(&volume_24h)?;
         Ok(PriceInfo {
             token: product.token.clone(),
             unit: product.unit.clone(),
             value,
-            reliability: volume,
+            reliability: Decimal::ONE,
         })
     }
 }
@@ -133,7 +127,6 @@ enum CoinbaseResponse {
     Ticker {
         product_id: String,
         price: String,
-        volume_24h: String,
     },
 }
 

--- a/src/sources/crypto_com.rs
+++ b/src/sources/crypto_com.rs
@@ -107,12 +107,11 @@ impl CryptoComSource {
             }
             let data = &result.data[0];
             let value = Decimal::from_str(&data.best_bid_price)?;
-            let volume = Decimal::from_str(&data.volume_24h)?;
             sink.send(PriceInfo {
                 token: stream.token.clone(),
                 unit: stream.unit.clone(),
                 value,
-                reliability: volume,
+                reliability: Decimal::ONE,
             })?;
         }
 
@@ -159,6 +158,4 @@ struct CryptoComResponseResult {
 struct CryptoComResponseData {
     #[serde(rename = "b")]
     best_bid_price: String,
-    #[serde(rename = "v")]
-    volume_24h: String,
 }

--- a/src/sources/kucoin.rs
+++ b/src/sources/kucoin.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use anyhow::{Context, Result, bail};
 use futures::{FutureExt as _, SinkExt, StreamExt, future::BoxFuture};
 use rand::{RngCore, thread_rng};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use tokio::{
     net::TcpStream,
@@ -96,7 +97,7 @@ impl KucoinSource {
                     token: symbol.token.clone(),
                     unit: symbol.unit.clone(),
                     value: data.data.buy.try_into()?,
-                    reliability: data.data.vol.try_into()?,
+                    reliability: Decimal::ONE,
                 })?;
             }
             bail!("Kucoin stream has closed")
@@ -162,7 +163,6 @@ struct KucoinMessage {
 struct KucoinResponseData {
     symbol: String,
     buy: f64,
-    vol: f64,
 }
 
 #[derive(Deserialize)]

--- a/src/sources/maestro.rs
+++ b/src/sources/maestro.rs
@@ -1,6 +1,7 @@
 use anyhow::{Result, anyhow};
 use futures::{FutureExt, future::BoxFuture};
 use reqwest::Client;
+use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::{env, sync::Arc, time::Duration};
 use tokio::{task::JoinSet, time::sleep};
@@ -99,13 +100,12 @@ impl MaestroSource {
         let contents = response.text().await?;
         let messages: [MaestroOHLCMessage; 1] = serde_json::from_str(&contents)?;
         let res = (messages[0].coin_a_open + messages[0].coin_a_close) / 2.;
-        let volume = messages[0].coin_a_volume;
 
         sink.send(PriceInfo {
             token: config.token.to_string(),
             unit: config.unit.to_string(),
             value: res.try_into()?,
-            reliability: volume.try_into()?,
+            reliability: Decimal::ONE,
         })?;
         Ok(())
     }
@@ -115,5 +115,4 @@ impl MaestroSource {
 struct MaestroOHLCMessage {
     coin_a_open: f64,
     coin_a_close: f64,
-    coin_a_volume: f64,
 }


### PR DESCRIPTION
For (almost) every CEX, we've been using self-reported exchange volume as a proxy for reliability, to weight prices based on which source has the most throughput. This is apparently a bad idea, because reported volume is manipulable by both end users and the CEX itself.

Switch to ignoring volume, and giving each of these sources a "reliability" of exactly 1. They have equal weights to each other, and no manipulation can give a CEX any advantage over any others.

We continue to use TVL as a metric of reliability for DEXes; it's harder to manipulate (though not impossible), and gives a more direct signal of relative trust in a source.