### PR TITLE
feat: add CSWAP as a new DEX price source

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -487,6 +487,13 @@ splash:
   max_concurrency: 3
   retries: 3
   timeout_ms: 5000
+cswap:
+  pools:
+    - token: ANGELS
+      unit: ADA
+      credential: ed97e0a1394724bb7cb94f20acf627abc253694c92b88bf8fb4b7f6f/*
+      asset_id: 6f1073916b3a51446ab380304ca42215c8df032c63af66a07cda086a.63
+  max_concurrency: 3
 vyfi:
   pools:
     - token: BTN

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,7 @@ struct RawOracleConfig {
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub splash: SplashConfig,
+    pub cswap: CSwapConfig,
     pub vyfi: VyFiConfig,
     pub wingriders: WingRidersConfig,
 }
@@ -90,6 +91,7 @@ pub struct OracleConfig {
     pub sundaeswap: SundaeSwapConfig,
     pub minswap: MinswapConfig,
     pub splash: SplashConfig,
+    pub cswap: CSwapConfig,
     pub vyfi: VyFiConfig,
     pub wingriders: WingRidersConfig,
 }
@@ -231,6 +233,7 @@ impl TryFrom<RawOracleConfig> for OracleConfig {
             sundaeswap: raw.sundaeswap,
             minswap: raw.minswap,
             splash: raw.splash,
+            cswap: raw.cswap,
             vyfi: raw.vyfi,
             wingriders: raw.wingriders,
         })
@@ -470,6 +473,14 @@ pub struct MinswapConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SplashConfig {
+    #[serde(flatten)]
+    pub kupo: RawKupoConfig,
+    pub pools: Vec<Pool>,
+    pub max_concurrency: usize,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct CSwapConfig {
     #[serde(flatten)]
     pub kupo: RawKupoConfig,
     pub pools: Vec<Pool>,

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -29,6 +29,7 @@ use crate::{
         bybit::ByBitSource,
         coinbase::CoinbaseSource,
         crypto_com::CryptoComSource,
+        cswap::CSwapSource,
         fxratesapi::FxRatesApiSource,
         kucoin::KucoinSource,
         maestro::MaestroSource,
@@ -92,6 +93,7 @@ impl PriceAggregator {
             SourceAdapter::new(MinswapSource::new(&config)?, &config),
             SourceAdapter::new(OkxSource::new(&config)?, &config),
             SourceAdapter::new(SplashSource::new(&config)?, &config),
+            SourceAdapter::new(CSwapSource::new(&config)?, &config),
             SourceAdapter::new(VyFiSource::new(&config)?, &config),
             SourceAdapter::new(WingRidersSource::new(&config)?, &config),
         ];

--- a/src/sources/cswap.rs
+++ b/src/sources/cswap.rs
@@ -1,0 +1,127 @@
+use std::{sync::Arc, time::Duration};
+
+use anyhow::{Result, anyhow};
+use futures::{FutureExt, future::BoxFuture};
+use rust_decimal::Decimal;
+use tokio::time::sleep;
+use tracing::{Level, warn};
+
+use crate::config::{HydratedPool, OracleConfig};
+
+use super::{
+    kupo::{MaxConcurrencyFutureSet, get_asset_value, wait_for_sync},
+    source::{PriceInfo, PriceSink, Source},
+};
+
+pub struct CSwapSource {
+    client: Arc<kupon::Client>,
+    max_concurrency: usize,
+    pools: Vec<HydratedPool>,
+}
+
+impl Source for CSwapSource {
+    fn name(&self) -> String {
+        "CSwap".into()
+    }
+
+    fn tokens(&self) -> Vec<String> {
+        self.pools.iter().map(|p| p.pool.token.clone()).collect()
+    }
+
+    fn query<'a>(&'a self, sink: &'a PriceSink) -> BoxFuture<'a, Result<()>> {
+        self.query_impl(sink).boxed()
+    }
+}
+
+impl CSwapSource {
+    pub fn new(config: &OracleConfig) -> Result<Self> {
+        let cswap_config = &config.cswap;
+        let client = config
+            .kupo_with_overrides(&cswap_config.kupo)
+            .new_client()?;
+        Ok(Self {
+            client: Arc::new(client),
+            max_concurrency: cswap_config.max_concurrency,
+            pools: config.hydrate_pools(&cswap_config.pools),
+        })
+    }
+
+    async fn query_impl(&self, sink: &PriceSink) -> Result<()> {
+        loop {
+            self.query_cswap(sink).await?;
+            sleep(Duration::from_secs(3)).await;
+        }
+    }
+
+    #[tracing::instrument(err(Debug, level = Level::WARN), skip_all)]
+    async fn query_cswap(&self, sink: &PriceSink) -> Result<()> {
+        wait_for_sync(&self.client).await;
+
+        let mut set = MaxConcurrencyFutureSet::new(self.max_concurrency);
+        for pool in &self.pools {
+            let client = self.client.clone();
+            let pool = pool.clone();
+            let options = pool.pool.kupo_query();
+
+            set.push(async move {
+                let mut result = client.matches(&options).await?;
+                if result.is_empty() {
+                    return Err(anyhow!("pool not found for {}", pool.pool.token));
+                }
+                if result.len() > 1 {
+                    return Err(anyhow!("more than one pool found for {}", pool.pool.token));
+                }
+                let matc = result.remove(0);
+                let Some(token_value) = get_asset_value(&matc, &pool.token_asset_id) else {
+                    return Err(anyhow!(
+                        "no value found for asset {:?}",
+                        pool.token_asset_id
+                    ));
+                };
+                let Some(unit_value) = get_asset_value(&matc, &pool.unit_asset_id) else {
+                    return Err(anyhow!("no value found for asset {:?}", pool.unit_asset_id));
+                };
+                if unit_value == 0 {
+                    return Err(anyhow!(
+                        "CSwap reported value of {} as zero, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                if token_value == 0 {
+                    return Err(anyhow!(
+                        "CSwap reported value of {} as infinite, ignoring",
+                        pool.pool.token
+                    ));
+                }
+                let value = Decimal::new(unit_value as i64, pool.unit_digits)
+                    / Decimal::new(token_value as i64, pool.token_digits);
+                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+
+                sink.send_named(
+                    PriceInfo {
+                        token: pool.pool.token.clone(),
+                        unit: pool.pool.unit.clone(),
+                        value,
+                        reliability: tvl,
+                    },
+                    &pool.pool.asset_id,
+                )?;
+                Ok(())
+            });
+        }
+
+        while let Some(res) = set.next().await {
+            match res {
+                Err(error) => {
+                    // the task ran, but returned an error
+                    warn!("error querying cswap: {}", error);
+                }
+                Ok(()) => {
+                    // all is well
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -2,6 +2,7 @@ pub mod binance;
 pub mod bybit;
 pub mod coinbase;
 pub mod crypto_com;
+pub mod cswap;
 pub mod fxratesapi;
 pub mod kucoin;
 pub mod kupo;


### PR DESCRIPTION
## Summary
- Add support for CSWAP DEX to the oracle network
- Implement standard Kupo-based price source for CSWAP
- Configure initial ANGELS/ADA pool

## Details
This PR adds CSWAP as a new price source for the Butane oracle network. The implementation follows the established pattern used by other Kupo-based DEX sources (Minswap, Splash, VyFi, WingRiders) to maintain consistency across the codebase.

### Changes:
- **New source file**: `src/sources/cswap.rs` - Standard Kupo-based DEX implementation
- **Config updates**: Added `CSwapConfig` struct and integration in `src/config.rs`
- **Price aggregator**: Integrated CSWAP source initialization
- **Base config**: Added ANGELS/ADA pool configuration with:
  - Validator: `ed97e0a1394724bb7cb94f20acf627abc253694c92b88bf8fb4b7f6f/*`
  - LP Token: `6f1073916b3a51446ab380304ca42215c8df032c63af66a07cda086a.63`

### Testing
- [x] Code compiles successfully (`cargo check` passes)
- [x] Follows existing DEX source patterns
- [ ] Requires testing with actual Kupo instance

## Notes
The CSWAP source uses the same implementation pattern as other DEXs, reading liquidity directly from UTXO values rather than parsing datum structures. This ensures consistency and maintainability across all DEX integrations.

🤖 Generated with [Claude Code](https://claude.ai/code)