### PR TITLE
feat: read minswap datum to find right assets

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,12 @@ use tracing::Level;
 
 use crate::{keys, network::NodeId};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Asset {
+    Ada,
+    Native(AssetId),
+}
+
 const fn default_enabled() -> bool {
     true
 }
@@ -145,15 +151,15 @@ impl OracleConfig {
         self.currencies.iter().map(|c| (&c.name, c)).collect()
     }
 
-    fn find_asset_id(asset: &CurrencyConfig) -> Option<AssetId> {
+    fn find_asset_id(asset: &CurrencyConfig) -> Asset {
         if asset.name == "ADA" {
-            return None;
+            return Asset::Ada;
         }
         let asset_id = asset
             .asset_id
             .as_ref()
             .unwrap_or_else(|| panic!("Token {} has no asset id", asset.name));
-        Some(AssetId::from_hex(asset_id))
+        Asset::Native(AssetId::from_hex(asset_id))
     }
 }
 
@@ -610,9 +616,9 @@ impl Pool {
 #[derive(Debug, Clone)]
 pub struct HydratedPool {
     pub pool: Pool,
-    pub token_asset_id: Option<AssetId>,
+    pub token_asset_id: Asset,
     pub token_digits: u32,
-    pub unit_asset_id: Option<AssetId>,
+    pub unit_asset_id: Asset,
     pub unit_digits: u32,
 }
 

--- a/src/sources/kupo.rs
+++ b/src/sources/kupo.rs
@@ -2,11 +2,11 @@ use std::time::Duration;
 
 use anyhow::{Result, bail};
 use futures::{Future, StreamExt, stream::FuturesUnordered};
-use kupon::{AssetId, Client, HealthStatus, Match};
+use kupon::{Client, HealthStatus, Match};
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
-use crate::config::HydratedPool;
+use crate::config::{Asset, HydratedPool};
 
 pub async fn wait_for_sync(client: &Client) {
     let mut last_status = None;
@@ -59,17 +59,13 @@ pub async fn wait_for_sync(client: &Client) {
 pub fn find_match(matches: Vec<Match>, pool: &HydratedPool) -> Result<Match> {
     let mut best_match = None;
     for m in matches {
-        if pool
-            .token_asset_id
-            .as_ref()
-            .is_some_and(|id| !m.value.assets.contains_key(id))
+        if let Asset::Native(id) = &pool.token_asset_id
+            && !m.value.assets.contains_key(id)
         {
             continue;
         }
-        if pool
-            .unit_asset_id
-            .as_ref()
-            .is_some_and(|id| !m.value.assets.contains_key(id))
+        if let Asset::Native(id) = &pool.unit_asset_id
+            && !m.value.assets.contains_key(id)
         {
             continue;
         }
@@ -85,18 +81,14 @@ pub fn find_match(matches: Vec<Match>, pool: &HydratedPool) -> Result<Match> {
     }
 }
 
-pub fn get_asset_value(matc: &Match, asset_id: &Option<AssetId>) -> Option<u64> {
+pub fn get_asset_value(matc: &Match, asset_id: &Asset) -> Option<u64> {
     get_asset_value_minus_tx_fee(matc, asset_id, 0)
 }
 
-pub fn get_asset_value_minus_tx_fee(
-    matc: &Match,
-    asset_id: &Option<AssetId>,
-    tx_fee: u64,
-) -> Option<u64> {
+pub fn get_asset_value_minus_tx_fee(matc: &Match, asset_id: &Asset, tx_fee: u64) -> Option<u64> {
     match asset_id {
-        Some(token) => matc.value.assets.get(token).copied(),
-        None => matc.value.coins.checked_sub(tx_fee),
+        Asset::Ada => matc.value.coins.checked_sub(tx_fee),
+        Asset::Native(token) => matc.value.assets.get(token).copied(),
     }
 }
 

--- a/src/sources/minswap.rs
+++ b/src/sources/minswap.rs
@@ -2,11 +2,13 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::{Result, anyhow};
 use futures::{FutureExt, future::BoxFuture};
+use kupon::AssetId;
+use pallas_primitives::PlutusData;
 use rust_decimal::Decimal;
 use tokio::time::sleep;
 use tracing::{Level, warn};
 
-use crate::config::{HydratedPool, OracleConfig};
+use crate::config::{Asset, HydratedPool, OracleConfig};
 
 use super::{
     kupo::{MaxConcurrencyFutureSet, find_match, get_asset_value, wait_for_sync},
@@ -65,7 +67,19 @@ impl MinswapSource {
 
             set.push(async move {
                 let result = client.matches(&options).await?;
-                let matc = find_match(result, &pool)?;
+                let mut matches = vec![];
+                for m in result {
+                    let Some(hash) = &m.datum else {
+                        continue;
+                    };
+                    let Some(data) = client.datum(&hash.hash).await? else {
+                        continue;
+                    };
+                    if is_for_assets(&data, &pool) {
+                        matches.push(m);
+                    }
+                }
+                let matc = find_match(matches, &pool)?;
                 let Some(token_value) = get_asset_value(&matc, &pool.token_asset_id) else {
                     return Err(anyhow!(
                         "no value found for asset {:?}",
@@ -117,5 +131,57 @@ impl MinswapSource {
         }
 
         Ok(())
+    }
+}
+
+fn is_for_assets(data: &str, pool: &HydratedPool) -> bool {
+    let v1 = pool
+        .pool
+        .credential
+        .as_ref()
+        .is_some_and(|c| c == "e1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec13309/*");
+    let Some((a, b)) = extract_assets(data, v1) else {
+        return false;
+    };
+    (a == pool.token_asset_id && b == pool.unit_asset_id)
+        || (a == pool.unit_asset_id && b == pool.token_asset_id)
+}
+
+fn extract_assets(data: &str, v1: bool) -> Option<(Asset, Asset)> {
+    let bytes = hex::decode(data).ok()?;
+    let decoded: PlutusData = minicbor::decode(&bytes).ok()?;
+    let PlutusData::Constr(constr) = decoded else {
+        return None;
+    };
+    let (a_index, b_index) = if v1 { (0, 1) } else { (1, 2) };
+    Some((
+        extract_asset(constr.fields.get(a_index)?)?,
+        extract_asset(constr.fields.get(b_index)?)?,
+    ))
+}
+
+fn extract_asset(asset: &PlutusData) -> Option<Asset> {
+    let PlutusData::Constr(constr) = asset else {
+        return None;
+    };
+    if constr.fields.len() > 2 {
+        return None;
+    }
+    let (PlutusData::BoundedBytes(policy_id), PlutusData::BoundedBytes(asset_name)) =
+        (constr.fields.first()?, constr.fields.get(1)?)
+    else {
+        return None;
+    };
+    if policy_id.is_empty() && asset_name.is_empty() {
+        Some(Asset::Ada)
+    } else {
+        Some(Asset::Native(AssetId {
+            policy_id: policy_id.to_string(),
+            asset_name: if asset_name.is_empty() {
+                None
+            } else {
+                Some(asset_name.to_string())
+            },
+        }))
     }
 }


### PR DESCRIPTION
Minswap has multiple NIGHT "pools" which our system can detect, most of which aren't actually for NIGHT. Refine our output matching logic by parsing the Minswap pool datum.