### PR TITLE
fix(ci): prevent tag injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
       publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -76,8 +75,14 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            dist host --steps=create --tag "$TAG" --output-format=json > plan-dist-manifest.json
+          else
+            dist plan --output-format=json > plan-dist-manifest.json
+          fi
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -112,6 +117,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      TAG: ${{ needs.plan.outputs.tag }}
     steps:
       - name: enable windows longpaths
         run: |
@@ -142,7 +148,11 @@ jobs:
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot
-          dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          if [[ -n "$TAG" ]]; then
+            dist build --tag "$TAG" --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          else
+            dist build --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          fi
           echo "dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -174,6 +184,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+      TAG: ${{ needs.plan.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,7 +206,11 @@ jobs:
       - id: cargo-dist
         shell: bash
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          if [[ -n "$TAG" ]]; then
+            dist build --tag "$TAG" --output-format=json "--artifacts=global" > dist-manifest.json
+          else
+            dist build --output-format=json "--artifacts=global" > dist-manifest.json
+          fi
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
@@ -221,6 +236,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ needs.plan.outputs.tag }}
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
@@ -245,7 +261,7 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist host --tag "$TAG" --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation

- The release workflow interpolated `github.ref_name` directly into shell `run` blocks which created a command-injection vector when tags contain shell metacharacters. 
- The intent is to preserve release behavior while eliminating unquoted tag text from shell command construction so CI secrets cannot be exfiltrated.

### Description

- Removed the `tag-flag` workflow output that preformatted `--tag=...` with `github.ref_name` to avoid embedding untrusted text into shell fragments. 
- Pass the raw tag through a safe environment variable `TAG` in the `plan` step and propagate `TAG` into downstream job `env` contexts. 
- Rewrote `plan`, local/global `build` and `host` run blocks to call `dist` with either `--tag "$TAG"` (quoted) or no `--tag` when empty, and to branch on the event type without building shell snippets from the tag. 
- Kept existing behavior (dist plan/host logic and conditional publishing) while eliminating direct interpolation of `github.ref_name` into `run` script text.

### Testing

- Ran a repository search for remaining unsafe patterns with `rg -n "tag-flag|github.ref_name" .github/workflows/release.yml` and verified no direct interpolation remains in `run` blocks. 
- Visually inspected all `dist` invocations in `.github/workflows/release.yml` to confirm they now use the `TAG` env var and quoted `--tag "$TAG"` or omit the flag when empty. 
- Attempted a YAML parse using Python (`yaml.safe_load`) but the environment lacked `PyYAML`, so that automated parse check could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb344a5d083299b56a815cbbdc8c2)