### PR TITLE
fix: restrict /force-election to localhost callers

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use axum::{
     Json, Router,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::StatusCode,
     response::IntoResponse,
     routing::{get, post},
@@ -177,7 +177,12 @@ impl HealthServer {
                     return;
                 }
             };
-            if let Err(error) = axum::serve(listener, app).await {
+            if let Err(error) = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            {
                 warn!("Health server stopped: {}", error);
             }
         });
@@ -292,8 +297,17 @@ struct RunElectionRequest {
 
 async fn force_election(
     State(state): State<HealthState>,
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
     Json(req): Json<RunElectionRequest>,
 ) -> impl IntoResponse {
+    if !remote_addr.ip().is_loopback() {
+        warn!(
+            remote_addr = %remote_addr,
+            "Rejected remote force-election request from non-loopback address"
+        );
+        return StatusCode::FORBIDDEN;
+    }
+
     state.raft_client.assume_leadership(req.term);
     StatusCode::ACCEPTED
 }


### PR DESCRIPTION
### Motivation
- The health server exposed an unauthenticated `POST /force-election` endpoint bound to `0.0.0.0` that could invoke `assume_leadership` with an attacker-chosen term and destabilize Raft availability.

### Description
- Add `ConnectInfo<SocketAddr>` and import `SocketAddr` so the handler can inspect the caller's socket address.
- Use `app.into_make_service_with_connect_info::<SocketAddr>()` when serving the Axum router to populate connection info for handlers.
- Modify `force_election` to reject non-loopback callers with `403 FORBIDDEN` and a warning log while preserving existing behavior for local callers.
- Keep all existing request/response semantics and call into `raft_client.assume_leadership(req.term)` for allowed requests.

### Testing
- Ran `cargo check` against the workspace and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba6cd4fec8329817e13471c7296fa)