### PR TITLE
fix(ci): replace unpinned third‑party cache action with actions/cache@v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,11 +56,16 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: Rust Cache
+      - name: Cargo Cache
         id: cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
         with:
-          prefix-key: ${{ matrix.rust_target }}
+          path: |
+            cargo-registry-cache
+            sccache-cache
+          key: ${{ matrix.rust_target }}-cargo-cache-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.rust_target }}-cargo-cache
 
       - name: Compile
         run: cargo build --release --target ${{ matrix.rust_target }}

--- a/.github/workflows/refresh-docker-cache.yml
+++ b/.github/workflows/refresh-docker-cache.yml
@@ -49,11 +49,16 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: Rust Cache
+      - name: Cargo Cache
         id: cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
         with:
-          prefix-key: ${{ matrix.rust_target }}
+          path: |
+            cargo-registry-cache
+            sccache-cache
+          key: ${{ matrix.rust_target }}-cargo-cache-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.rust_target }}-cargo-cache
 
       - name: Compile
         run: cargo build --release --target ${{ matrix.rust_target }}


### PR DESCRIPTION
### Motivation
- A mutable third‑party action `Swatinem/rust-cache@v2` was introduced in Docker-related workflows and created a CI supply‑chain risk because the tag is not pinned to a commit SHA and the publish workflow has elevated/persistent credentials. 
- Restore a safe, previously used caching method while preserving per‑target cache behavior to remove the exposure without altering build logic.

### Description
- Replaced `uses: Swatinem/rust-cache@v2` with `uses: actions/cache@v4` in `.github/workflows/docker.yml` and `.github/workflows/refresh-docker-cache.yml`.
- Restored the `path`, `key`, and `restore-keys` configuration so caching remains scoped per Rust target and keeps `cargo-registry-cache` and `sccache-cache` directories.
- Renamed the step back to `Cargo Cache` to match prior semantics and kept the compile/build steps unchanged.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/patch-format problems and it succeeded.
- Committed the change with `git commit` and inspected the commit stat using `git show --stat`, which succeeded.
- Attempted to parse the workflow YAML with `python` + `yaml.safe_load` but it failed due to the environment missing the `PyYAML` module (`ModuleNotFoundError`), so automated YAML schema validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba631a1348329b648b69e430e4f47)