### PR TITLE
fix: restore count-based outlier quorum in price aggregation

### DIFF
--- a/src/price_aggregator/conversions.rs
+++ b/src/price_aggregator/conversions.rs
@@ -148,7 +148,7 @@ impl<'a> TokenPriceConverter<'a> {
         }
 
         // Find the weighted median of all prices being considered
-        let total_weight: BigRational = candidate_prices.iter().map(|(_, _, weight)| weight).sum();
+        let total_sources = candidate_prices.len();
         let median_price = find_weighted_median(&candidate_prices)?;
 
         // Filter out "outlier" prices which are too distant from the median
@@ -168,10 +168,8 @@ impl<'a> TokenPriceConverter<'a> {
             }
         });
 
-        // if more than half of our prices by weight are outliers, these prices are too unstable to use
-        let remaining_weight: BigRational =
-            candidate_prices.iter().map(|(_, _, weight)| weight).sum();
-        if remaining_weight < total_weight / BigRational::new(BigInt::from(2), BigInt::one()) {
+        // if half or more of our sources are outliers, these prices are too unstable to use
+        if candidate_prices.len() < 1 + total_sources / 2 {
             return None;
         }
 
@@ -965,6 +963,52 @@ mod tests {
             converter.value_in_usd("LENFI"),
             Some(decimal_rational(100, 0))
         );
+    }
+
+
+    #[test]
+    fn value_in_usd_should_not_allow_single_dominant_weight_source_after_outlier_filtering() {
+        let source_prices = vec![
+            (
+                "dominant source".into(),
+                PriceInfo {
+                    token: "LENFI".into(),
+                    unit: "USD".into(),
+                    value: Decimal::new(200, 0),
+                    reliability: Decimal::new(1000, 0),
+                },
+            ),
+            (
+                "honest source 1".into(),
+                PriceInfo {
+                    token: "LENFI".into(),
+                    unit: "USD".into(),
+                    value: Decimal::new(100, 0),
+                    reliability: Decimal::new(100, 0),
+                },
+            ),
+            (
+                "honest source 2".into(),
+                PriceInfo {
+                    token: "LENFI".into(),
+                    unit: "USD".into(),
+                    value: Decimal::new(101, 0),
+                    reliability: Decimal::new(100, 0),
+                },
+            ),
+        ];
+        let default_prices = vec![];
+        let synthetics = make_synthetics();
+        let currencies = make_currencies();
+        let converter = TokenPriceConverter::new(
+            &source_prices,
+            &default_prices,
+            &synthetics,
+            &currencies,
+            default_threshold(),
+        );
+
+        assert_eq!(converter.value_in_usd("LENFI"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The outlier-quorum logic was changed to use total weight remaining after filtering which allows a single dominant-weight source to survive outlier removal and determine the published price.
- The change restores multi-source integrity by requiring a majority of original sources (by count) to remain after outlier filtering before returning a price.

### Description
- Replaced the weight-based quorum check in `compute_value_in_usd` with a count-based majority check using `total_sources` and `candidate_prices.len()` in `src/price_aggregator/conversions.rs`.
- Kept the weighted median and weighted averaging behavior for normal aggregation, but require `candidate_prices.len() >= 1 + total_sources / 2` to proceed.
- Added a regression test `value_in_usd_should_not_allow_single_dominant_weight_source_after_outlier_filtering` to assert that a lone dominant-weight source cannot produce a price after outlier filtering.

### Testing
- Ran `cargo test -q value_in_usd_should_not_allow_single_dominant_weight_source_after_outlier_filtering` which passed.
- Ran `cargo test -q value_in_usd_should_not_report_price_if_sources_are_too_far_apart` which passed.
- Ran `cargo test -q value_in_usd_should_ignore_outlier_source` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba40b37548329be95bdf20f0c5e96)