### PR TITLE
fix: correct binance url

### DIFF
--- a/src/sources/binance.rs
+++ b/src/sources/binance.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::source::Source;
 
-const BASE_URL: &str = "wss://fstream.binance.com/stream";
+const BASE_URL: &str = "wss://fstream.binance.com/market/stream";
 
 pub struct BinanceSource {
     streams: BTreeMap<String, BinanceTokenConfig>,


### PR DESCRIPTION
We missed an [update to Binance's API](https://www.binance.com/en/support/announcement/detail/ebf9b0aa9eca4ff3804eef6fb09ba32a), changing the base url of the stream we need to use. The old URL "works", except that it waits forever for us to send a message (which we never actually did with this API). So it didn't show up in error logs, and just showed up in the health endpoint as a slow feed.