### PR TITLE
Be robust against low-TVL collateral 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pallas-crypto",
  "pallas-primitives",
+ "plutus-parser",
  "rand 0.8.7",
  "reqwest",
  "rust_decimal",
@@ -2112,6 +2113,29 @@ checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "plutus-parser"
+version = "1.0.0"
+source = "git+https://github.com/SundaeSwap-finance/plutus-parser?rev=cb27b9e#cb27b9ec28ff5d47f877fdd32fd5e2025d4dba43"
+dependencies = [
+ "hex",
+ "indexmap",
+ "minicbor",
+ "pallas-primitives",
+ "plutus-parser-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "plutus-parser-derive"
+version = "1.0.0"
+source = "git+https://github.com/SundaeSwap-finance/plutus-parser?rev=cb27b9e#cb27b9ec28ff5d47f877fdd32fd5e2025d4dba43"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,9 @@ num-traits = "0.2"
 opentelemetry = "0.32"
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "gzip-tonic", "tls", "tls-webpki-roots"] }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
-pallas-crypto = "1.0.0-alpha.3"
-pallas-primitives = "1.0.0-alpha.3"
+pallas-crypto = "1"
+pallas-primitives = "1"
+plutus-parser = { git = "https://github.com/SundaeSwap-finance/plutus-parser", rev = "cb27b9e", features = ["derive"] }
 rand = "0.8.5"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "query"] }
 rust_decimal = "1"

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -64,55 +64,55 @@ currencies:
   - name: BTN
     asset_id: 016be5325fd988fea98ad422fcfd53e5352cacfced5c106a932a35a4.42544e
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: DJED
     asset_id: 8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61.446a65644d6963726f555344
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: ENCS
     asset_id: 9abf0afd2f236a19f2842d502d0450cbcd9c79f123a9708f96fd9b96.454e4353
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: EUR
     digits: 6
   - name: FLDT
     asset_id: 577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e.0014df10464c4454
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: IAG
     asset_id: 5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114.494147
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: iETH
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69455448
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: iUSD
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69555344
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: JPY
     digits: 6
   - name: LENFI
     asset_id: 8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587.41414441
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: LQ
     asset_id: da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24.4c51
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: MIN
     asset_id: 29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6.4d494e
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: myUSD
     asset_id: 92776616f1f32c65a173392e4410a3d8c39dcf6ef768c73af164779c.4d79555344
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: NIGHT
     asset_id: 0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa.4e49474854
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: PAXG
     digits: 4
   - name: POL
@@ -120,17 +120,17 @@ currencies:
   - name: SHEN
     asset_id: 8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61.5368656e4d6963726f555344
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: SNEK
     asset_id: 279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b
     digits: 0
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: SOL
     digits: 9
   - name: SUNDAE
     asset_id: 9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77.53554e444145
     digits: 6
-    min_tvl: 20_000_000
+    min_tvl: 20
   - name: USD
     digits: 6
   - name: USDT

--- a/config.base.yaml
+++ b/config.base.yaml
@@ -64,55 +64,55 @@ currencies:
   - name: BTN
     asset_id: 016be5325fd988fea98ad422fcfd53e5352cacfced5c106a932a35a4.42544e
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: DJED
     asset_id: 8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61.446a65644d6963726f555344
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: ENCS
     asset_id: 9abf0afd2f236a19f2842d502d0450cbcd9c79f123a9708f96fd9b96.454e4353
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: EUR
     digits: 6
   - name: FLDT
     asset_id: 577f0b1342f8f8f4aed3388b80a8535812950c7a892495c0ecdf0f1e.0014df10464c4454
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: IAG
     asset_id: 5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114.494147
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: iETH
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69455448
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: iUSD
     asset_id: f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880.69555344
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: JPY
     digits: 6
   - name: LENFI
     asset_id: 8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587.41414441
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: LQ
     asset_id: da8c30857834c6ae7203935b89278c532b3995245295456f993e1d24.4c51
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: MIN
     asset_id: 29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6.4d494e
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: myUSD
     asset_id: 92776616f1f32c65a173392e4410a3d8c39dcf6ef768c73af164779c.4d79555344
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: NIGHT
     asset_id: 0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa.4e49474854
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: PAXG
     digits: 4
   - name: POL
@@ -120,17 +120,17 @@ currencies:
   - name: SHEN
     asset_id: 8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61.5368656e4d6963726f555344
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: SNEK
     asset_id: 279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b
     digits: 0
-    min_tvl: 20
+    min_tvl: 500
   - name: SOL
     digits: 9
   - name: SUNDAE
     asset_id: 9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d77.53554e444145
     digits: 6
-    min_tvl: 20
+    min_tvl: 500
   - name: USD
     digits: 6
   - name: USDT

--- a/src/config.rs
+++ b/src/config.rs
@@ -396,6 +396,8 @@ pub struct CurrencyConfig {
     pub name: String,
     pub asset_id: Option<String>,
     pub digits: u32,
+    /// The minimum TVL, in whole USD, a source must report before its price for
+    /// this currency is considered.
     #[serde(default)]
     pub min_tvl: Decimal,
 }

--- a/src/price_aggregator.rs
+++ b/src/price_aggregator.rs
@@ -305,9 +305,12 @@ impl PriceAggregator {
 
         let mut prices = vec![];
         for collateral in &collateral {
-            let collateral_digits = self.get_digits(collateral);
-            let Some(p) = converter.value_in_usd(collateral) else {
-                bail!("could not compute price for collateral {collateral}");
+            if !collateral.enabled {
+                prices.push(BigRational::new(BigInt::ZERO, BigInt::ONE));
+            }
+            let collateral_digits = self.get_digits(&collateral.name);
+            let Some(p) = converter.value_in_usd(&collateral.name) else {
+                bail!("could not compute price for collateral {}", collateral.name);
             };
             let p_scaled = p * BigInt::from(10i64.pow(synth_digits))
                 / BigInt::from(10i64.pow(collateral_digits));
@@ -315,10 +318,10 @@ impl PriceAggregator {
         }
 
         // track prices before smoothing, to measure the effect of smoothing
-        for (collateral_name, collateral_price) in collateral.iter().zip(prices.iter()) {
+        for (collateral, collateral_price) in collateral.iter().zip(prices.iter()) {
             let price = collateral_price.to_f64().expect("infallible");
             debug!(
-                collateral_name,
+                collateral_name = collateral.name,
                 synthetic_name = synth.name,
                 histogram.raw_collateral_price = price,
                 "pre-smoothing price metrics",
@@ -329,10 +332,10 @@ impl PriceAggregator {
         let prices = self.apply_synth_gema(&synth.name, prices);
 
         // track metrics for the different prices
-        for (collateral_name, collateral_price) in collateral.iter().zip(prices.iter()) {
+        for (collateral, collateral_price) in collateral.iter().zip(prices.iter()) {
             let price = collateral_price.to_f64().expect("infallible");
             debug!(
-                collateral_name,
+                collateral_name = collateral.name,
                 synthetic_name = synth.name,
                 histogram.collateral_price = price,
                 "price metrics",
@@ -346,7 +349,7 @@ impl PriceAggregator {
         Ok(SyntheticPriceData {
             price: synth_price,
             feed: SyntheticPriceFeed {
-                collateral_names: Some(collateral),
+                collateral_names: Some(collateral.iter().map(|c| c.name.clone()).collect()),
                 collateral_prices,
                 synthetic: synth.name.clone(),
                 denominator,

--- a/src/price_aggregator/synth_config_source.rs
+++ b/src/price_aggregator/synth_config_source.rs
@@ -11,10 +11,11 @@ use anyhow::{Result, bail};
 use futures::{StreamExt, stream::FuturesUnordered};
 use kupon::MatchOptions;
 use pallas_primitives::{Constr, PlutusData};
+use plutus_parser::AsPlutus;
 
 struct CollateralState {
     config: CollateralConfig,
-    collateral: Option<Vec<String>>,
+    collateral: Option<Vec<Collateral>>,
 }
 
 pub struct SyntheticConfigSource {
@@ -129,20 +130,22 @@ impl SyntheticConfigSource {
                 };
 
                 let mut collateral = vec![];
-                for AssetClass {
-                    policy_id,
-                    asset_name,
-                } in collateral_assets
-                {
-                    if policy_id.is_empty() && asset_name.is_empty() {
-                        collateral.push("ADA".to_string());
+                for (ac, enabled) in collateral_assets {
+                    if ac.policy_id.is_empty() && ac.asset_name.is_empty() {
+                        collateral.push(Collateral {
+                            name: "ADA".to_string(),
+                            enabled,
+                        });
                         continue;
                     }
-                    let asset_id = format!("{policy_id}.{asset_name}");
+                    let asset_id = format!("{}.{}", ac.policy_id, ac.asset_name);
                     let Some(name) = asset_names.get(&asset_id) else {
                         fail!(true, "unrecognized asset id {asset_id}");
                     };
-                    collateral.push(name.clone());
+                    collateral.push(Collateral {
+                        name: name.clone(),
+                        enabled,
+                    });
                 }
 
                 Ok((synthetic, collateral))
@@ -176,12 +179,23 @@ impl SyntheticConfigSource {
         self.next_refresh = now + Duration::from_secs(30);
     }
 
-    pub fn synthetic_collateral(&self, name: &str) -> Option<Vec<String>> {
+    // TODO: report "disabled" collateral entries, make the node just report their prices as 0
+    pub fn synthetic_collateral(&self, name: &str) -> Option<Vec<Collateral>> {
         let state = self.collateral.get(name)?;
         if let Some(collateral) = &state.collateral {
             Some(collateral.clone())
         } else if !state.config.list.is_empty() {
-            Some(state.config.list.clone())
+            Some(
+                state
+                    .config
+                    .list
+                    .iter()
+                    .map(|c| Collateral {
+                        name: c.clone(),
+                        enabled: true,
+                    })
+                    .collect(),
+            )
         } else {
             None
         }
@@ -189,33 +203,25 @@ impl SyntheticConfigSource {
 }
 
 // input is a MonoDatum from the butane Aiken definition
-fn extract_collateral_assets(datum: PlutusData) -> Result<Vec<AssetClass>> {
+fn extract_collateral_assets(datum: PlutusData) -> Result<Vec<(AssetClass, bool)>> {
     // extract the ParamsWrapper
     let [wrapper] = decode_struct(datum, 0)?;
     // extract the LiveParams
     let [params] = decode_struct(wrapper, 0)?;
-    // extract the collateral assets from the LiveParams
-    let [collateral_assets] = decode_struct(params, 0)?;
+    // extract the collateral assets and weights from the LiveParams
+    let [collateral_assets, weights] = decode_struct(params, 0)?;
 
-    let PlutusData::Array(collateral_assets) = collateral_assets else {
-        bail!("datum has invalid collateral assets");
-    };
-
-    let mut assets = vec![];
-    for (index, asset) in collateral_assets.to_vec().into_iter().enumerate() {
-        let [policy_id, asset_name] = decode_struct(asset, 0)?;
-        let PlutusData::BoundedBytes(policy_id) = policy_id else {
-            bail!("asset {index} has invalid policy id");
-        };
-        let PlutusData::BoundedBytes(asset_name) = asset_name else {
-            bail!("asset {index} has invalid asset name");
-        };
-        assets.push(AssetClass {
-            policy_id: policy_id.into(),
-            asset_name: asset_name.into(),
-        });
+    let assets: Vec<AssetClass> = AsPlutus::from_plutus(collateral_assets)?;
+    let weights: Vec<u64> = AsPlutus::from_plutus(weights)?;
+    if assets.len() != weights.len() {
+        bail!(
+            "mismatched number of assets ({}) and weights ({})",
+            assets.len(),
+            weights.len()
+        );
     }
-    Ok(assets)
+    let enabled = weights.iter().map(|w| *w > 0);
+    Ok(assets.into_iter().zip(enabled).collect())
 }
 
 fn decode_struct<const N: usize>(datum: PlutusData, variant: u64) -> Result<[PlutusData; N]> {
@@ -246,7 +252,14 @@ struct UpdateConfigError {
     clear: bool,
 }
 
+#[derive(AsPlutus)]
 struct AssetClass {
     policy_id: String,
     asset_name: String,
+}
+
+#[derive(Clone)]
+pub struct Collateral {
+    pub name: String,
+    pub enabled: bool,
 }

--- a/src/sources/minswap.rs
+++ b/src/sources/minswap.rs
@@ -103,7 +103,7 @@ impl MinswapSource {
                 }
                 let value = Decimal::new(unit_value as i64, pool.unit_digits)
                     / Decimal::new(token_value as i64, pool.token_digits);
-                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+                let tvl = Decimal::new(unit_value as i64 * 2, pool.unit_digits);
 
                 sink.send_named(
                     PriceInfo {

--- a/src/sources/source.rs
+++ b/src/sources/source.rs
@@ -12,6 +12,11 @@ pub struct PriceInfo {
     pub token: String,
     pub unit: String,
     pub value: Decimal,
+    /// How much weight this price should carry relative to other sources.
+    /// Sources which can measure liquidity (i.e. DEX pools) report the TVL of
+    /// the pool, denominated in whole `unit` tokens (not the smallest
+    /// denomination), so that multiplying by the price of `unit` in USD yields
+    /// a TVL in whole USD. Sources with no notion of liquidity report 1.
     pub reliability: Decimal,
 }
 

--- a/src/sources/splash.rs
+++ b/src/sources/splash.rs
@@ -89,7 +89,7 @@ impl SplashSource {
                 }
                 let value = Decimal::new(unit_value as i64, pool.unit_digits)
                     / Decimal::new(token_value as i64, pool.token_digits);
-                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+                let tvl = Decimal::new(unit_value as i64 * 2, pool.unit_digits);
 
                 sink.send_named(
                     PriceInfo {

--- a/src/sources/sundaeswap.rs
+++ b/src/sources/sundaeswap.rs
@@ -147,7 +147,7 @@ impl SundaeSwapSource {
 
             let value = Decimal::new(unit_value, pool.asset_a.decimals)
                 / Decimal::new(token_value, pool.asset_b.decimals);
-            let tvl = Decimal::new(unit_value * 2, 0);
+            let tvl = Decimal::new(unit_value * 2, pool.asset_a.decimals);
 
             sink.send_named(
                 PriceInfo {

--- a/src/sources/sundaeswap_kupo.rs
+++ b/src/sources/sundaeswap_kupo.rs
@@ -111,7 +111,7 @@ impl SundaeSwapKupoSource {
 
                 let value = Decimal::new(unit_value as i64, pool.unit_digits)
                     / Decimal::new(token_value as i64, pool.token_digits);
-                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+                let tvl = Decimal::new(unit_value as i64 * 2, pool.unit_digits);
 
                 sink.send_named(
                     PriceInfo {

--- a/src/sources/vyfi.rs
+++ b/src/sources/vyfi.rs
@@ -87,7 +87,7 @@ impl VyFiSource {
                 }
                 let value = Decimal::new(unit_value as i64, pool.unit_digits)
                     / Decimal::new(token_value as i64, pool.token_digits);
-                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+                let tvl = Decimal::new(unit_value as i64 * 2, pool.unit_digits);
 
                 sink.send_named(
                     PriceInfo {

--- a/src/sources/wingriders.rs
+++ b/src/sources/wingriders.rs
@@ -89,7 +89,7 @@ impl WingRidersSource {
                 }
                 let value = Decimal::new(unit_value as i64, pool.unit_digits)
                     / Decimal::new(token_value as i64, pool.token_digits);
-                let tvl = Decimal::new(unit_value as i64 * 2, 0);
+                let tvl = Decimal::new(unit_value as i64 * 2, pool.unit_digits);
 
                 sink.send_named(
                     PriceInfo {


### PR DESCRIPTION
This PR has two changes.

## Disabling collateral

For each synthetic, we now read the butane protocol params to find the weights assigned to each collateral. We "disable" any collateral with a weight of 0 (meaning we give it the price `0` in any payloads we produce).

The point of this change is to have a fast way to disable broken collateral. We won't even try to get a price for any "disabled" collateral, so we don't have to worry about coordinating that price between consumers.

## Normalizing Min TVL

The `min_tvl` field in our price configs is now always in units of USD. Before, its units varied depending on which currency we were considering.

I have also bumped the min TVL to $500 USD. When deciding prices, we will ignore any DEX pool with less than $500 of TVL.